### PR TITLE
Changes nonce from 32-bit number to string of base64 bytes

### DIFF
--- a/draft-meunier-web-bot-auth-architecture.md
+++ b/draft-meunier-web-bot-auth-architecture.md
@@ -185,7 +185,7 @@ Origins MAY want to prevent signatures from being spoofed or used multiple times
 Agents SHOULD extend `@signature-parameters` defined in {{generating-http-message-signature}} as follow
 
 `nonce`
-: base64url encoded random string
+: base64url encoded random byte array. It is RECOMMENDED to use a 64-byte array.
 
 This `nonce` MUST be unique for the validity window of the signature, as defined by created and expires attributes.
 Because the `nonce` is controlled by the client, the origin needs to maintain a list of all nonces that it has seen that are still in the validity window of the signature.


### PR DESCRIPTION
This PR changes the nonce from a 32-bit number to a string containing base64 encoded bytes.

My rationale is:

1. Not fixing the size of the nonce enables signers to avoid nonce collisions by selecting the nonce from a larger space.
2. [RFC 9421 HTTP Message Signatures Section-5.1](https://www.rfc-editor.org/rfc/rfc9421#section-5.1) allows the verifier to specify in the Accept-Signature header the nonce a signer must use in the signature they generate. Existing code may not assume this nonce is limited to 32-bits.
3. RFC 9421 uses strings of base64 encoded bytes in the examples for nonces so this limitation would be unexpected.
4. It allows for the use of signed or otherwise authenticated nonces such as those generated by a random beacon.

Perhaps we shouldn't limit this to strings of base64 encoded bytes. RFC 9421 defines the nonce as just a string defining it as:

> nonce:  A random unique value generated for this signature as a String value.

What do you think @thibmeu?


