### PR TITLE
Correct reference for @authority

### DIFF
--- a/draft-meunier-web-bot-auth-architecture.md
+++ b/draft-meunier-web-bot-auth-architecture.md
@@ -156,7 +156,7 @@ Signature verification can be performed either directly by origins or delegated 
 Agents MUST include the following component:
 
 `@authority`
-: as defined in {{Section 2.2.1 of HTTP-MESSAGE-SIGNATURES}}
+: as defined in {{Section 2.2.3 of HTTP-MESSAGE-SIGNATURES}}
 
 Agents MUST include the following `@signature-params` as defined in {{Section 2.3 of HTTP-MESSAGE-SIGNATURES}}
 


### PR DESCRIPTION
Reference points to Section 2.2.1 ([Method](https://www.rfc-editor.org/rfc/rfc9421#section-2.2.1)), but authority is defined in 2.2.3 ([Authority](https://www.rfc-editor.org/rfc/rfc9421#section-2.2.3)).