### PR TITLE
Change Signature-Agent to a sf-dictionary

### DIFF
--- a/draft-meunier-http-message-signatures-directory.md
+++ b/draft-meunier-http-message-signatures-directory.md
@@ -99,10 +99,16 @@ defined in {{configuration}}.
 ## Header Field Definition
 
 The `Signature-Agent` header field is an Item Structured Header {{STRUCTURED-HEADERS}}. Its value MUST be a
-String containing a {{URI}}. The ABNF is:
+Dictionary which member values are {{URI}}. The ABNF is:
 
 ~~~
-Signature-Agent = sf-string   ; Section 3.3.3 of {{STRUCTURED-HEADERS}}
+Signature-Agent = sf-dictionary   ; Section 3.2 of {{STRUCTURED-HEADERS}}
+
+;;; adapted from Section 3.2 of {{STRUCTURED-HEADERS}}
+sf-dictionary  = dict-member *( OWS "," OWS dict-member )
+dict-member    = member-key ( "=" member-value )
+member-key     = key
+member-value   = sf-string        ; Section 3.3.3 of {{STRUCTURED-HEADERS}}
 ~~~
 
 The URI scheme MUST be one of:
@@ -424,7 +430,7 @@ This extend the examples from {{Appendix B of HTTP-MESSAGE-SIGNATURES}}.
 ~~~
 POST /foo?param=Value&Pet=dog HTTP/1.1
 Host: example.com
-Signature-Agent: https://directory.test
+Signature-Agent: my_test="https://directory.test"
 {"hello": "world"}
 
 HTTP/1.1 200 OK
@@ -440,7 +446,7 @@ In this example, the directory is signed by `example.com`. The CA is self-signed
 ~~~
 POST /foo?param=Value&Pet=dog HTTP/1.1
 Host: example.com
-Signature-Agent: data:application/http-message-signatures-directory;utf8,{"keys":[{"kty":"OKP","crv":"Ed25519","kid":"NFcWBst6DXG-N35nHdzMrioWntdzNZghQSkjHNMMSjw","x":"JrQLj5P_89iXES9-vFgrIy29clF9CC_oPPsw3c5D0bs","use":"sig","nbf":1712793600,"exp":1715385600,"x5c":["MIIBYTCCAQagAwIBAgIUFDXRG3pgZ6txehQO2LT4aCqI3f0wCgYIKoZIzj0EAwIwFjEUMBIGA1UEAwwLZXhhbXBsZS5jb20wHhcNMjUwNjEzMTA0MjQxWhcNMzUwNjExMTA0MjQxWjAaMRgwFgYDVQQDDA9zdWIuZXhhbXBsZS5jb20wKjAFBgMrZXADIQAmtAuPk//z2JcRL368WCsjLb1yUX0IL+g8+zDdzkPRu6NdMFswCQYDVR0TBAIwADAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0OBBYEFKV3qaYNFbzQB1QmN4sa13+t4RmoMB8GA1UdIwQYMBaAFFtwp5gX95/2N9L349xEbCEJ17vUMAoGCCqGSM49BAMCA0kAMEYCIQC8r+GvvNnjI+zzOEDMOM/g9e8QLm00IZXP+tjDqah1UQIhAJHffLke9iEP1pUdm+oRLrq6bUqyLELi5TH2t+BaagKv","MIIBcDCCARagAwIBAgIUS502rlCXxG2vviltGdfe3fmX4pIwCgYIKoZIzj0EAwIwFjEUMBIGA1UEAwwLZXhhbXBsZS5jb20wHhcNMjUwNjEzMTA0MTQzWhcNMzUwNjExMTA0MTQzWjAWMRQwEgYDVQQDDAtleGFtcGxlLmNvbTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABEIlSPiPt4L/teyjdERSxyoeVY+9b3O+XkjpMjLMRcWxbEzRDEy41bihcTnpSILImSVymTQl9BQZq36QpCpJQnKjQjBAMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgIEMB0GA1UdDgQWBBRbcKeYF/ef9jfS9+PcRGwhCde71DAKBggqhkjOPQQDAgNIADBFAiEAwTOqm1zNAvZuQ8Zb5AftQIZotq4Xe6GHz3+nJ04ybgoCIEEZtn1Pa+GCbmbWh12piHJBKh09TCA0feTedisbwzPV"]}]}
+Signature-Agent: my_test="data:application/http-message-signatures-directory;utf8,{\"keys\":[{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"kid\":\"NFcWBst6DXG-N35nHdzMrioWntdzNZghQSkjHNMMSjw\",\"x\":\"JrQLj5P_89iXES9-vFgrIy29clF9CC_oPPsw3c5D0bs\",\"use\":\"sig\",\"nbf\":1712793600,\"exp\":1715385600,\"x5c\":[\"MIIBYTCCAQagAwIBAgIUFDXRG3pgZ6txehQO2LT4aCqI3f0wCgYIKoZIzj0EAwIwFjEUMBIGA1UEAwwLZXhhbXBsZS5jb20wHhcNMjUwNjEzMTA0MjQxWhcNMzUwNjExMTA0MjQxWjAaMRgwFgYDVQQDDA9zdWIuZXhhbXBsZS5jb20wKjAFBgMrZXADIQAmtAuPk//z2JcRL368WCsjLb1yUX0IL+g8+zDdzkPRu6NdMFswCQYDVR0TBAIwADAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0OBBYEFKV3qaYNFbzQB1QmN4sa13+t4RmoMB8GA1UdIwQYMBaAFFtwp5gX95/2N9L349xEbCEJ17vUMAoGCCqGSM49BAMCA0kAMEYCIQC8r+GvvNnjI+zzOEDMOM/g9e8QLm00IZXP+tjDqah1UQIhAJHffLke9iEP1pUdm+oRLrq6bUqyLELi5TH2t+BaagKv\",\"MIIBcDCCARagAwIBAgIUS502rlCXxG2vviltGdfe3fmX4pIwCgYIKoZIzj0EAwIwFjEUMBIGA1UEAwwLZXhhbXBsZS5jb20wHhcNMjUwNjEzMTA0MTQzWhcNMzUwNjExMTA0MTQzWjAWMRQwEgYDVQQDDAtleGFtcGxlLmNvbTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABEIlSPiPt4L/teyjdERSxyoeVY+9b3O+XkjpMjLMRcWxbEzRDEy41bihcTnpSILImSVymTQl9BQZq36QpCpJQnKjQjBAMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgIEMB0GA1UdDgQWBBRbcKeYF/ef9jfS9+PcRGwhCde71DAKBggqhkjOPQQDAgNIADBFAiEAwTOqm1zNAvZuQ8Zb5AftQIZotq4Xe6GHz3+nJ04ybgoCIEEZtn1Pa+GCbmbWh12piHJBKh09TCA0feTedisbwzPV\"]}]}"
 {"hello": "world"}
 
 HTTP/1.1 200 OK

--- a/draft-meunier-http-message-signatures-directory.md
+++ b/draft-meunier-http-message-signatures-directory.md
@@ -98,17 +98,11 @@ defined in {{configuration}}.
 
 ## Header Field Definition
 
-The `Signature-Agent` header field is an Item Structured Header {{STRUCTURED-HEADERS}}. Its value MUST be a
-Dictionary which member values are {{URI}}. The ABNF is:
+The `Signature-Agent` header field is an Dictionary Structured Header {{STRUCTURED-HEADERS}}.
+Its value MUST be a Dictionary which member values are {{URI}}. The ABNF is:
 
 ~~~
 Signature-Agent = sf-dictionary   ; Section 3.2 of {{STRUCTURED-HEADERS}}
-
-;;; adapted from Section 3.2 of {{STRUCTURED-HEADERS}}
-sf-dictionary  = dict-member *( OWS "," OWS dict-member )
-dict-member    = member-key ( "=" member-value )
-member-key     = key
-member-value   = sf-string        ; Section 3.3.3 of {{STRUCTURED-HEADERS}}
 ~~~
 
 The URI scheme MUST be one of:
@@ -121,8 +115,8 @@ When using the "data" URI scheme, the media type MUST be
 `application/http-message-signatures-directory+json`. The content MAY be base64 encoded
 as per {{BASE64}}.
 
-Multiple `Signature-Agent` header fields MAY be present in a request. Processors SHOULD
-use the first valid URI that provides a valid key directory.
+If dictonary values are not a valid URI-reference, the entire header field MAY be
+ignored.
 
 # Security Considerations {#security}
 

--- a/draft-meunier-http-message-signatures-directory.md
+++ b/draft-meunier-http-message-signatures-directory.md
@@ -98,12 +98,9 @@ defined in {{configuration}}.
 
 ## Header Field Definition
 
-The `Signature-Agent` header field is an Dictionary Structured Header {{STRUCTURED-HEADERS}}.
-Its value MUST be a Dictionary which member values are {{URI}}. The ABNF is:
-
-~~~
-Signature-Agent = sf-dictionary   ; Section 3.2 of {{STRUCTURED-HEADERS}}
-~~~
+The `Signature-Agent` header field is an Dictionary Structured Header as defined
+in {{Section 3.2 of STRUCTURED-HEADERS}}.
+Its member values MUST be an String Item which contain a {{URI}}.
 
 The URI scheme MUST be one of:
 

--- a/draft-meunier-web-bot-auth-architecture.md
+++ b/draft-meunier-web-bot-auth-architecture.md
@@ -149,7 +149,11 @@ validates the signature, and processes the request if the signature is valid.
 
 ## Deployment Models
 
-Signature verification can be performed either directly by origins or delegated to a fronting proxy. Direct verification by origins provides simplicity and control. Proxy verification offloads processing and enables shared caching across multiple origins. The choice depends on traffic volume and operational requirements.
+Signature verification can be performed either directly by origins or delegated
+to a fronting proxy. Direct verification by origins provides simplicity and
+control. Proxy verification offloads processing and enables shared caching across
+multiple origins. The choice depends on traffic volume and operational
+requirements.
 
 ## Generating HTTP Message Signature {#generating-http-message-signature}
 
@@ -357,7 +361,6 @@ the `Signature` and `Signature-Agent` headers before the origin does.
 A proxy SHOULD NOT strip the `Signature` or `Signature-Agent` headers from
 requests.
 
-
 A proxy SHOULD NOT replay signatures against other reverse proxies used by the
 origin, as this allows impersonation of the principal signature agent.
 
@@ -371,6 +374,38 @@ or provide its own nonce in an `Accept-Signature` response to challenge the agen
 Such policies MAY incur additional round-trip between the client and the origin
 to convey `accept-signature` header, or deployment specific exchanges.
 
+### Signature-Agent labeling
+
+An intermediary is allowed to relabel an existing signature when processing the
+message, per {{Section 7.2.5 of HTTP-MESSAGE-SIGNATURES}}.
+
+This MAY apply to `Signature-Agent`, when included in the request as defined in
+{{signature-agent}},
+An intermediary updating the member key MUST update the components of the
+associated signatures accordingly.
+
+For instance, an intermediary updating the `Signature-Agent` from `sig2` to
+`sig3` on the example provided in {{example-signature-agent-included}} would
+result in the following `Signature`, `Signature-Input`, and `Signature-Agent`
+header.
+
+~~~
+NOTE: '\' line wrapping per RFC 8792
+
+Signature-Agent: sig3="https://signature-agent.test"
+Signature-Input: sig2=("@authority" "signature-agent";key="sig3")\
+ ;created=1735689600\
+ ;keyid="oD0HwocPBSfpNy5W3bpJeyFGY_IQ_YpqxSjQ3Yd-CLA"\
+ ;alg="rsa-pss-sha512"\
+ ;expires=1735693200\
+ ;nonce="XSHtZVCThSIAksXsH9WBs6AtxtXC0eQGiIcUGSoJstFs8lAWakjhrfwzLhyjtme5iXMZvmFWqDEs6cT3Jf+BbQ=="\
+ ;tag="web-bot-auth"
+Signature: sig2=:I1QWNzGXdP1a4dSvOHLCVOOanEYHDk+ZsVxM9MLX/p4ko69ghKwR5EOtAD96g7g4GWP7lmpM/jFAf9q8EFRDTPLjUXySwMv4YPgabv2LQihTJG2y8a2m6IGltyruwQNiqSJVUuRaG9+b17CGmAMFZh30X6GXLdQJrCARpeTqPwp2DC+a8haDE/VE5EruqzjA5/2mKwvrkzkSqeW5tOVtFwWRRHIOidquf/8Je6kM9mhgkg4arudLA5SL4wyyYE1jURIgcOl8agrfdJ5Def23DIRtiOLRa8jT9cpTLFAuFHN+mrZA/LH9h0gSIg1cPb+0cMASee5uku1KjWcFer7jWA==:
+~~~
+
+`Signature` is unchanged as the base is similar. Both `Signature-Agent` and
+`Signature-Input` reflect the update from `sig2` to `sig3`.
+.
 # Privacy Considerations
 
 ## Public Identity
@@ -448,7 +483,7 @@ Signature-Input: sig1=("@authority")\
 Signature: sig1=:ppXhcGjVp7xaoHGIa7V+hsSxuRgFt8i04K4FWz9ORJtn57t8duD3cyavsnh9grdWWOJHER8ITNBaqe4mKmPq193S+7hSW31IzXSH4/9WfsdrjUBwyJ0fhBU7oNn3UGDqwdhr5TMgVI2/EX8saV5GrOunM09zMEA+d4QWYyKRFJmg+asCs253l2IYPpVp4N55H0uRK7qhb7acng8LNiEPTQZD2s+Kha95LgeciKQSO0jgR/h59fX/dXqLdFIvRMn8Ggs2VUzF/f/MMEXH83gufVnh4SYl/rKMSKWDBsK+OiLpobAVIuIz+HLCVlMnxlkXkhCW2J/Pmo8jht9N5k/y1A==:
 ~~~
 
-### Signature-Agent included present on the request
+### Signature-Agent included present on the request {#example-signature-agent-included}
 
 This example presents a minimal signature using the rsa-pss-sha512 algorithm over test-request. The request contains
 a `Signature-Agent` header.

--- a/draft-meunier-web-bot-auth-architecture.md
+++ b/draft-meunier-web-bot-auth-architecture.md
@@ -184,13 +184,15 @@ It is RECOMMENDED the expiry to be no more than 24 hours.
 
 `Signature-Agent` is an HTTP Method context header defined in Section 4.1 of {{DIRECTORY}}.
 It is RECOMMENDED that the Agent sends requests with `Signature-Agent` header, as described in {{sending-request}}.
-If the header is to be sent, it MUST be signed as a component as defined in {{Section 2.1 of HTTP-MESSAGE-SIGNATURES}}.
+If the header is to be sent, one of its members MUST be signed as a component as defined in {{Section 2.1 of HTTP-MESSAGE-SIGNATURES}}.
 
 This results in the following components to be signed
 
 ~~~
-("@authority" "signature-agent")
+("@authority" "signature-agent";key="sig1")
 ~~~
+
+It is RECOMMENDED that the `key` matches the signature label.
 
 ### Anti-replay {#anti-replay}
 
@@ -219,21 +221,21 @@ and request a new signature, as described in {{requesting-message-signature}}.
 An Agent SHOULD send a request with the signature generated above. Updating the architecture diagram, the flow looks as follow.
 
 ~~~aasvg
-+---------+                                                                    +----------+
-|         |                              Exchange                              |          |
-|         |<=========================  Cryptographic  ========================>|          |
-|         |                              material                              |          |
-|  Agent  |                                                                    |  Origin  |
-|         |     .-----------------------------------------------------.        |          |
-|         +-----| GET /path/to/resource                               |------->|          |
-|         |     | Signature: abc==                                    |        |          |
-+---------+     | Signature-Input: sig=(@authority signature-agent);\ |        +----------+
-                |                  created=1700000000;\               |
-                |                  expires=1700011111;\               |
-                |                  keyid="ba3e64==";\                 |
-                |                  tag="web-bot-auth"                 |
-                | Signature-Agent: "https://signer.example.com"       |
-                '-----------------------------------------------------'
++---------+                                                                                  +----------+
+|         |                                     Exchange                                     |          |
+|         |<================================  Cryptographic  ===============================>|          |
+|         |                                     material                                     |          |
+|  Agent  |                                                                                  |  Origin  |
+|         |     .-------------------------------------------------------------------.        |          |
+|         +-----| GET /path/to/resource                                             |------->|          |
+|         |     | Signature: abc==                                                  |        |          |
++---------+     | Signature-Input: sig=("@authority" "signature-agent";key="sig");\ |        +----------+
+                |                  created=1700000000;\                             |
+                |                  expires=1700011111;\                             |
+                |                  keyid="ba3e64==";\                               |
+                |                  tag="web-bot-auth"                               |
+                | Signature-Agent: sig="https://signer.example.com"                 |
+                '-------------------------------------------------------------------'
 ~~~
 
 The Agent SHOULD send requests with two headers
@@ -457,8 +459,8 @@ The corresponding signature base is:
 NOTE: '\' line wrapping per RFC 8792
 
 "@authority": example.com
-"signature-agent": "https://signature-agent.test"
-"@signature-params": ("@authority" "signature-agent")\
+"signature-agent": sig2="https://signature-agent.test"
+"@signature-params": ("@authority" "signature-agent";key="sig2")\
  ;created=1735689600\
  ;keyid="oD0HwocPBSfpNy5W3bpJeyFGY_IQ_YpqxSjQ3Yd-CLA"\
  ;alg="rsa-pss-sha512"\
@@ -472,8 +474,8 @@ This results in the following Signature-Input and Signature header fields being 
 ~~~
 NOTE: '\' line wrapping per RFC 8792
 
-Signature-Agent: "https://signature-agent.test"
-Signature-Input: sig2=("@authority" "signature-agent")\
+Signature-Agent: sig2="https://signature-agent.test"
+Signature-Input: sig2=("@authority" "signature-agent";key="sig2")\
  ;created=1735689600\
  ;keyid="oD0HwocPBSfpNy5W3bpJeyFGY_IQ_YpqxSjQ3Yd-CLA"\
  ;alg="rsa-pss-sha512"\
@@ -534,8 +536,8 @@ The corresponding signature base is:
 NOTE: '\' line wrapping per RFC 8792
 
 "@authority": example.com
-"signature-agent": "https://signature-agent.test"
-"@signature-params": ("@authority" "signature-agent")\
+"signature-agent": sig2="https://signature-agent.test"
+"@signature-params": ("@authority" "signature-agent";key="sig2")\
  ;created=1735689600\
  ;keyid="poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U"\
  ;alg="ed25519"\
@@ -549,8 +551,8 @@ This results in the following Signature-Input and Signature header fields being 
 ~~~
 NOTE: '\' line wrapping per RFC 8792
 
-Signature-Agent: "https://signature-agent.test"
-Signature-Input: sig2=("@authority" "signature-agent")\
+Signature-Agent: sig2="https://signature-agent.test"
+Signature-Input: sig2=("@authority" "signature-agent";key="sig2")\
  ;created=1735689600\
  ;keyid="poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U"\
  ;alg="ed25519"\


### PR DESCRIPTION
both for directory and architecture

Using @sandormajor proposal

```
Signature-Input: sig1=(... "signature-agent";key="sig1");...
Signature: sig1=:3ase6A==:

Signature-Input: sig2=(... "signature-agent";key="sig2");...
Signature: sig2=:3ase6A==:

Signature-Agent: sig1="https://example.com"
Signature-Agent: sig2="https://agent.example"
```

close #70