### PR TITLE
Add req flag on directory response

### DIFF
--- a/draft-meunier-http-message-signatures-directory.md
+++ b/draft-meunier-http-message-signatures-directory.md
@@ -144,7 +144,7 @@ Each key SHOULD be used to provide one signature.
 Directory server SHOULD include:
 
 `@authority`
-: as defined in {{Section 2.2.3 of HTTP-MESSAGE-SIGNATURES}}
+: as defined in {{Section 2.2.3 of HTTP-MESSAGE-SIGNATURES}}. `req` flag defined in {{Section 2.4 of HTTP-MESSAGE-SIGNATURES}} MUST be set.
 
 Directory server SHOULD include the following `@signature-params` as defined in
 {{Section 2.3 of HTTP-MESSAGE-SIGNATURES}}


### PR DESCRIPTION
Directory is signing it's response. It is including @authority component from the request. It should therefore have a `req` flag set.

@sandormajor for review

Closes #72