### PR TITLE
clarify signature-agent as an url

### DIFF
--- a/draft-meunier-web-bot-auth-architecture.md
+++ b/draft-meunier-web-bot-auth-architecture.md
@@ -284,7 +284,7 @@ Origin MAY require the `nonce` to satisfy certain constraint: be globally unique
 
 This section describes the discovery mechanism for the agent directory.
 
-The reference for discovery is an HTTPS URL whose host component is a FQDN. It SHOULD provide a directory hosted on the well known registered in Section 4 of {{DIRECTORY}}.
+The reference for discovery is a URL. It SHOULD be an HTTPS URL. It SHOULD provide a directory hosted on the well known registered in Section 4 of {{DIRECTORY}}.
 
 Example:
 

--- a/draft-meunier-web-bot-auth-architecture.md
+++ b/draft-meunier-web-bot-auth-architecture.md
@@ -284,7 +284,7 @@ Origin MAY require the `nonce` to satisfy certain constraint: be globally unique
 
 This section describes the discovery mechanism for the agent directory.
 
-The reference for discovery is a FQDN. It SHOULD provide a directory hosted on the well known registered in Section 4 of {{DIRECTORY}}.
+The reference for discovery is an HTTPS URL whose host component is a FQDN. It SHOULD provide a directory hosted on the well known registered in Section 4 of {{DIRECTORY}}.
 
 Example:
 


### PR DESCRIPTION
I'm sorry if this is a nitpick, but I personally ran into confusion over the format of the `Signature-Agent`.

At first pass I implemented it strictly as a FQDN (`subdomain.site.com`), and then later realized the examples included the scheme.

An additional note: I was glad the scheme was included since it is difficult to do local development/testing over https. It was convenient to programmatically switch to http for that while strictly requiring https in production.