### PR TITLE
[registry] Improve pull-based registry consumption and add optional subcription via notifications.

### DIFF
--- a/draft-meunier-webbotauth-registry.md
+++ b/draft-meunier-webbotauth-registry.md
@@ -119,7 +119,7 @@ This section describes Signature Agent Card, a JSON object containing parameters
   "rate-control": "429",
   "rate-expectation": "avg=10rps;max=100rps",
   "known-urls": ["/", "/robots.txt", "*.png"],
-  "signature_directory_url": "https://example.com/.well-known/http-message-signatures-directory",
+  "jwks_uri": "https://example.com/.well-known/http-message-signatures-directory",
   "keys": [{
     "kty": "OKP",
     "crv": "Ed25519",
@@ -278,9 +278,10 @@ Example
 * `["/favicon.ico"]`
 * `["/index.html"]`
 
-## Signature Directory URL {#signature-agent-parameter-signature-directory-url}
+## JWKS URI {#signature-agent-parameter-jwks-uri}
 
-The `signature_directory_url` parameter provides the URL of the signature agent's
+The `jwks_uri` parameter provides the URL of the signature agent's
+JWKS keys as defined in {{Section 5 of JWK}}. This covers
 HTTP Message Signatures Directory as defined in {{DIRECTORY}}.
 
 When present, this parameter separates key material discovery from metadata
@@ -290,8 +291,8 @@ registry operators to host metadata and key material on different endpoints,
 supporting deployment scenarios where the registry endpoint itself contains
 signature agent card metadata but the key directory is hosted elsewhere.
 
-If both `signature_directory_url` and `keys` are present, the
-`signature_directory_url` takes precedence for key discovery.
+If both `jwks_uri` and `keys` are present, the
+`jwks_uri` takes precedence for key discovery.
 
 The URI scheme MUST be `https`.
 
@@ -334,7 +335,7 @@ https://crawler2.example.com/.well-known/http-message-signatures-directory
 https://zerotrust-gateway.example.com/v1/signature-agent-card
 
 # Below is an inlined card with the data URL scheme
-data:application/json,{"client_name":"Inline Bot","signature_directory_url":"https://inline.example.com/.well-known/http-message-signatures-directory"}
+data:application/json,{"client_name":"Inline Bot","jwks_uri":"https://inline.example.com/.well-known/http-message-signatures-directory"}
 ~~~
 
 ## Formal Syntax
@@ -802,19 +803,19 @@ in {{signature-agent-card}} in this registry.
 **Notes:**
 : N/A
 
-#### Signature Directory URL Parameter
+#### JWKS URI Parameter
 
 **Parameter Name:**
-: signature_directory_url
+: jwks_uri
 
 **Parameter Description:**
-: URL of the signature agent's HTTP Message Signatures Directory for key discovery
+: URL of the signature agent's key set. This can be an HTTP Message Signatures Directory for key discovery
 
 **Change Controller:**
 : IETF
 
 **Reference:**
-: {{signature-agent-parameter-signature-directory-url}}
+: {{signature-agent-parameter-jwks-uri}}
 
 **Notes:**
 : N/A
@@ -861,13 +862,10 @@ The editor would also like to thank the following individuals (listed in alphabe
 # Changelog
 {:numbered="false"}
 
-v03
-
-- Add optional `signature_directory_url` parameter to separate key material from metadata
-- Fix inline data URL example in registry to use valid signature agent card
-
 v02
 
+- Add optional `jwks_uri` parameter to separate key material from metadata
+- Fix inline data URL example in registry to use valid signature agent card
 - Rename "Public list" to "Registry Endpoint" for clarity
 - Add authentication guidance for private registry endpoints
 - Add conditional GET (ETag/If-Modified-Since) guidance for efficient polling

--- a/draft-meunier-webbotauth-registry.md
+++ b/draft-meunier-webbotauth-registry.md
@@ -46,6 +46,7 @@ normative:
   JWK: RFC7517
   JWK-OKP: RFC8037
   JWK-THUMBPRINT: RFC7638
+  WEB-LINKING: RFC8288
 
 
 informative:
@@ -353,15 +354,43 @@ UTF8-tail = %x80-BF
 A signature agent MAY submit their signature agent card to an origin, or the
 origin MAY manually add them to their local registry.
 
-## Public list
+## Registry Endpoint {#registry-endpoint}
 
 A registry MAY be provided via a GitHub repository, a public file server, or a
 dedicated endpoint.
 
 The registry SHOULD be served over HTTPS.
 
-A client application SHOULD validate the directory format and reject malformed
+A client application SHOULD validate the registry format and reject malformed
 entries.
+
+### Authentication {#registry-authentication}
+
+A registry endpoint MAY require authentication to restrict access to authorized
+consumers. This enables platforms to expose per-customer registries without
+revealing their customer list publicly.
+
+No specific authentication mechanism is mandated. Implementations MAY use
+pre-shared keys, bearer tokens as defined in {{OAUTH-BEARER}}, or HTTP Message
+Signatures as defined in {{HTTP-MESSAGE-SIGNATURES}}. HTTP Message Signatures
+are RECOMMENDED when key rotation without out-of-band coordination is desired.
+
+### Efficient Polling with Conditional Requests {#registry-conditional-requests}
+
+Registry servers SHOULD include `ETag` and `Last-Modified` response header
+fields as defined in {{Section 8.8 of HTTP}}.
+
+Consumers SHOULD send `If-None-Match` or `If-Modified-Since` precondition
+header fields as defined in {{Section 13.1 of HTTP}} on subsequent requests.
+A server SHOULD respond with `304 (Not Modified)` when the registry has not
+changed, avoiding redundant data transfer.
+
+### Caching {#registry-caching}
+
+Registry servers SHOULD include a `Cache-Control` response header field as
+defined in {{HTTP-CACHE}} to communicate the intended freshness lifetime of the
+registry content. Consumers SHOULD respect these cache directives and SHOULD NOT
+poll more frequently than indicated.
 
 ## Signature-Agent header {#signature-agent-header}
 
@@ -376,9 +405,36 @@ Agent Card MAY be discovered via a `Signature-Agent` header.
 Malicious actors may put properties which are not theirs in the registry. If signatures are present, clients MUST verify them.
 Clients SHOULD reject cards with invalid signatures.
 
+## Registry Integrity
+
+When a registry is served over HTTPS, TLS provides channel integrity between
+the server and the consumer. To additionally bind the registry contents to the
+platform's cryptographic identity, registry servers SHOULD sign their HTTP
+responses using {{HTTP-MESSAGE-SIGNATURES}} with a key present in the
+platform's own signature agent card. Consumers SHOULD verify such signatures
+when present.
+
+## Private Registries
+
+Registry endpoints that require authentication as described in
+{{registry-authentication}} limit exposure of a platform's customer list to
+authorized consumers only. Platforms SHOULD use authenticated registry
+endpoints when the enumeration of their customers is sensitive.
+
 # Privacy Considerations
 
-TODO
+## Customer List Exposure
+
+A publicly accessible registry reveals the set of customers registered with a
+platform. Platforms whose customer list is sensitive SHOULD restrict access to
+their registry endpoint as described in {{registry-authentication}}.
+
+## Access Patterns
+
+Registry servers SHOULD avoid logging personally identifiable information from
+consumer requests. Consumers accessing a registry reveal their interest in the
+platform's registered agents; registry servers SHOULD treat access logs as
+sensitive.
 
 
 # IANA Considerations {#iana}
@@ -682,6 +738,16 @@ The editor would also like to thank the following individuals (listed in alphabe
 
 # Changelog
 {:numbered="false"}
+
+v02
+
+- Rename "Public list" to "Registry Endpoint" for clarity
+- Add authentication guidance for private registry endpoints
+- Add conditional GET (ETag/If-Modified-Since) guidance for efficient polling
+- Add caching guidance referencing HTTP-CACHE
+- Expand Security Considerations: registry integrity via HTTP Message Signatures, private registry guidance
+- Expand Privacy Considerations: customer list exposure, access patterns
+- Add normative reference to RFC 8288 (Web Linking)
 
 v01
 

--- a/draft-meunier-webbotauth-registry.md
+++ b/draft-meunier-webbotauth-registry.md
@@ -400,6 +400,73 @@ format of `Signature-Agent` header as defined in {{Section 4.1 of DIRECTORY}}.
 When used for HTTP Message Signatures, and hosted on a well-known URL, Signature
 Agent Card MAY be discovered via a `Signature-Agent` header.
 
+## Change Notification {#change-notification}
+
+Pull-based consumption with conditional requests is sufficient for most
+deployments. When lower notification latency is required (e.g., to promptly
+act on platform relationship termination), a platform MAY implement a
+push-based change notification mechanism.
+
+### Advertising the Notification Endpoint {#notification-advertisement}
+
+A platform that supports change notifications SHOULD advertise its notification
+endpoint in the registry HTTP response using a `Link` header field as defined
+in {{WEB-LINKING}}:
+
+~~~
+Link: <https://platform.example/.well-known/registry-changes>; rel="registry-changes"
+~~~
+
+The `registry-changes` link relation identifies an endpoint to which consumers
+may register callbacks out of band.
+
+### Callback Registration {#notification-registration}
+
+Registration of a consumer callback URL with the platform is performed out of
+band. No specific registration protocol is defined by this document.
+
+### Notification Requests {#notification-requests}
+
+When an entry is added to or removed from its registry, the platform MUST send
+an HTTP request to each registered callback URL. The request:
+
+- MUST use `PUT` when an entry is added to the registry
+- MUST use `DELETE` when an entry is removed from the registry
+- MUST carry a body consisting of one or more registry lines in the format
+  defined in {{registry-endpoint}}, each identifying an affected
+  `signature_agent` URL
+- MUST be signed using {{HTTP-MESSAGE-SIGNATURES}} with a key present in the
+  platform's own signature agent card
+
+Example notification for an added entry:
+
+~~~
+PUT /registry-callback HTTP/1.1
+Host: waf.example
+Content-Type: text/plain
+Signature-Input: sig1=("@method" "@authority" "@path" "content-digest"); \
+  created=1741046400; keyid="NFcWBst6DXG-N35nHdzMrioWntdzNZghQSkjHNMMSjw"
+Signature: sig1=:base64signature:
+Content-Digest: sha-256=:base64hash:
+
+https://abc123.platform.example/.well-known/signature-agent-card
+~~~
+
+### Notification Processing {#notification-processing}
+
+Upon receiving a notification, the consumer MUST verify the HTTP Message
+Signature against the platform's key, discovered via the platform's
+`signature_agent` card. Notifications with missing or invalid signatures
+MUST be rejected.
+
+A notification is advisory only. The registry endpoint remains the authoritative
+source of truth. After verifying a notification, consumers SHOULD re-fetch the
+affected signature agent card to obtain current metadata.
+
+Platforms SHOULD retry delivery of failed notifications with exponential
+backoff. Consumers that miss notifications will recover on their next
+conditional pull from the registry endpoint.
+
 # Security Considerations
 
 Malicious actors may put properties which are not theirs in the registry. If signatures are present, clients MUST verify them.
@@ -745,6 +812,7 @@ v02
 - Add authentication guidance for private registry endpoints
 - Add conditional GET (ETag/If-Modified-Since) guidance for efficient polling
 - Add caching guidance referencing HTTP-CACHE
+- Add change notification section: PUT/DELETE webhook signed with HTTP Message Signatures, OOB callback registration, pull as source of truth
 - Expand Security Considerations: registry integrity via HTTP Message Signatures, private registry guidance
 - Expand Privacy Considerations: customer list exposure, access patterns
 - Add normative reference to RFC 8288 (Web Linking)

--- a/draft-meunier-webbotauth-registry.md
+++ b/draft-meunier-webbotauth-registry.md
@@ -50,11 +50,13 @@ normative:
 
 
 informative:
+  CDDL: RFC8610
   DATAURL: RFC2397
   OAUTH-BEARER: RFC6750
   OPENID-CONNECT-DISCOVERY:
     title: OpenID Connect Discovery 1.0
     target: https://openid.net/specs/openid-connect-discovery-1_0.html
+  PSK-TLS: RFC9257
   RATELIMIT-HEADER: I-D.draft-ietf-httpapi-ratelimit-headers
   RFC8446:
   ROBOTSTXT: RFC9309
@@ -371,7 +373,7 @@ consumers. This enables platforms to expose per-customer registries without
 revealing their customer list publicly.
 
 No specific authentication mechanism is mandated. Implementations MAY use
-pre-shared keys, bearer tokens as defined in {{OAUTH-BEARER}}, or HTTP Message
+pre-shared keys as mentioned in {{PSK-TLS}}, bearer tokens as defined in {{OAUTH-BEARER}}, or HTTP Message
 Signatures as defined in {{HTTP-MESSAGE-SIGNATURES}}. HTTP Message Signatures
 are RECOMMENDED when key rotation without out-of-band coordination is desired.
 
@@ -414,7 +416,7 @@ endpoint in the registry HTTP response using a `Link` header field as defined
 in {{WEB-LINKING}}:
 
 ~~~
-Link: <https://platform.example/.well-known/registry-changes>; rel="registry-changes"
+Link: <https://platform.example/v1/registry-changes>; rel="registry-changes"
 ~~~
 
 The `registry-changes` link relation identifies an endpoint to which consumers
@@ -428,35 +430,53 @@ band. No specific registration protocol is defined by this document.
 ### Notification Requests {#notification-requests}
 
 When an entry is added to or removed from its registry, the platform MUST send
-an HTTP request to each registered callback URL. The request:
+an HTTP request to each registered callback URL.
 
-- MUST use `PUT` when an entry is added to the registry
-- MUST use `DELETE` when an entry is removed from the registry
-- MUST carry a body consisting of one or more registry lines in the format
-  defined in {{registry-endpoint}}, each identifying an affected
-  `signature_agent` URL
-- MUST be signed using {{HTTP-MESSAGE-SIGNATURES}} with a key present in the
-  platform's own signature agent card
+The format in {{CDDL}} is as follow
+
+~~~cddl
+Action = "put" / "delete"
+
+Notification = {
+  action: Action,
+  signature-agent: tstr
+}
+~~~
+
+TODO: should we use application/json, a new media-type, permit binary encoding?
+TODO: should signature agent be an array?
+
+`action` denote the operation performed by the platform registry. The registry sends:
+1. `put` when there is a new entry in the registry,
+2. `delete` when an entry has been removed.
+
+The request MUST use `POST` to notify registered callback listeners.
+It MUST be signed using {{HTTP-MESSAGE-SIGNATURES}} with a key present in the platform's own signature agent card
+
+Media-Type SHOULD be "application/json".
 
 Example notification for an added entry:
 
 ~~~
-PUT /registry-callback HTTP/1.1
+POST /registry-callback HTTP/1.1
 Host: waf.example
-Content-Type: text/plain
+Content-Type: application/json
 Signature-Input: sig1=("@method" "@authority" "@path" "content-digest"); \
   created=1741046400; keyid="NFcWBst6DXG-N35nHdzMrioWntdzNZghQSkjHNMMSjw"
 Signature: sig1=:base64signature:
 Content-Digest: sha-256=:base64hash:
 
-https://abc123.platform.example/.well-known/signature-agent-card
+{
+  "action": "put",
+  "signature-agent": "https://abc123.platform.example/.well-known/signature-agent-card"
+}
 ~~~
 
 ### Notification Processing {#notification-processing}
 
 Upon receiving a notification, the consumer MUST verify the HTTP Message
 Signature against the platform's key, discovered via the platform's
-`signature_agent` card. Notifications with missing or invalid signatures
+`signature-agent` card. Notifications with missing or invalid signatures
 MUST be rejected.
 
 A notification is advisory only. The registry endpoint remains the authoritative
@@ -490,11 +510,7 @@ endpoints when the enumeration of their customers is sensitive.
 
 # Privacy Considerations
 
-## Customer List Exposure
-
-A publicly accessible registry reveals the set of customers registered with a
-platform. Platforms whose customer list is sensitive SHOULD restrict access to
-their registry endpoint as described in {{registry-authentication}}.
+TODO
 
 ## Access Patterns
 

--- a/draft-meunier-webbotauth-registry.md
+++ b/draft-meunier-webbotauth-registry.md
@@ -544,7 +544,7 @@ entries; registry servers SHOULD treat access logs as sensitive.
 
 # IANA Considerations {#iana}
 
-### Registration template
+## Registration template
 
 New registrations need to list the following attributes:
 

--- a/draft-meunier-webbotauth-registry.md
+++ b/draft-meunier-webbotauth-registry.md
@@ -369,8 +369,8 @@ entries.
 ### Authentication {#registry-authentication}
 
 A registry endpoint MAY require authentication to restrict access to authorized
-consumers. This enables platforms to expose per-customer registries without
-revealing their customer list publicly.
+clients. This allows a registry operator to expose registries without revealing
+their contents publicly.
 
 No specific authentication mechanism is mandated. Implementations MAY use
 pre-shared keys as mentioned in {{PSK-TLS}}, bearer tokens as defined in {{OAUTH-BEARER}}, or HTTP Message
@@ -382,7 +382,7 @@ are RECOMMENDED when key rotation without out-of-band coordination is desired.
 Registry servers SHOULD include `ETag` and `Last-Modified` response header
 fields as defined in {{Section 8.8 of HTTP}}.
 
-Consumers SHOULD send `If-None-Match` or `If-Modified-Since` precondition
+Clients SHOULD send `If-None-Match` or `If-Modified-Since` precondition
 header fields as defined in {{Section 13.1 of HTTP}} on subsequent requests.
 A server SHOULD respond with `304 (Not Modified)` when the registry has not
 changed, avoiding redundant data transfer.
@@ -391,7 +391,7 @@ changed, avoiding redundant data transfer.
 
 Registry servers SHOULD include a `Cache-Control` response header field as
 defined in {{HTTP-CACHE}} to communicate the intended freshness lifetime of the
-registry content. Consumers SHOULD respect these cache directives and SHOULD NOT
+registry content. Clients SHOULD respect these cache directives and SHOULD NOT
 poll more frequently than indicated.
 
 ## Signature-Agent header {#signature-agent-header}
@@ -406,33 +406,33 @@ Agent Card MAY be discovered via a `Signature-Agent` header.
 
 Pull-based consumption with conditional requests is sufficient for most
 deployments. When lower notification latency is required (e.g., to promptly
-act on platform relationship termination), a platform MAY implement a
-push-based change notification mechanism.
+act on entry removal), a registry operator MAY implement a push-based change
+notification mechanism.
 
 ### Advertising the Notification Endpoint {#notification-advertisement}
 
-A platform that supports change notifications SHOULD advertise its notification
-endpoint in the registry HTTP response using a `Link` header field as defined
-in {{WEB-LINKING}}:
+A registry operator that supports change notifications SHOULD advertise its
+notification endpoint in the registry HTTP response using a `Link` header field
+as defined in {{WEB-LINKING}}:
 
 ~~~
-Link: <https://platform.example/v1/registry-changes>; rel="registry-changes"
+Link: <https://registry.example/v1/registry-changes>; rel="registry-changes"
 ~~~
 
-The `registry-changes` link relation identifies an endpoint to which consumers
+The `registry-changes` link relation identifies an endpoint to which clients
 may register callbacks out of band.
 
 ### Callback Registration {#notification-registration}
 
-Registration of a consumer callback URL with the platform is performed out of
-band. No specific registration protocol is defined by this document.
+Registration of a client callback URL with the registry operator is performed
+out of band. No specific registration protocol is defined by this document.
 
 ### Notification Requests {#notification-requests}
 
-When an entry is added to or removed from its registry, the platform MUST send
-an HTTP request to each registered callback URL.
+When an entry is added to or removed from the registry, the registry operator
+MUST send an HTTP request to each registered callback URL.
 
-The format in {{CDDL}} is as follow
+The format in {{CDDL}} is as follows:
 
 ~~~cddl
 Action = "put" / "delete"
@@ -444,22 +444,23 @@ Notification = {
 ~~~
 
 TODO: should we use application/json, a new media-type, permit binary encoding?
-TODO: should signature agent be an array?
+TODO: should signature-agent be an array?
 
-`action` denote the operation performed by the platform registry. The registry sends:
-1. `put` when there is a new entry in the registry,
+`action` denotes the operation performed on the registry:
+1. `put` when a new entry has been added,
 2. `delete` when an entry has been removed.
 
-The request MUST use `POST` to notify registered callback listeners.
-It MUST be signed using {{HTTP-MESSAGE-SIGNATURES}} with a key present in the platform's own signature agent card
+The request MUST use `POST`.
+It MUST be signed using {{HTTP-MESSAGE-SIGNATURES}} with a key present in the
+registry operator's own signature agent card.
 
-Media-Type SHOULD be "application/json".
+The `Content-Type` SHOULD be `application/json`.
 
 Example notification for an added entry:
 
 ~~~
 POST /registry-callback HTTP/1.1
-Host: waf.example
+Host: origin.example
 Content-Type: application/json
 Signature-Input: sig1=("@method" "@authority" "@path" "content-digest"); \
   created=1741046400; keyid="NFcWBst6DXG-N35nHdzMrioWntdzNZghQSkjHNMMSjw"
@@ -468,23 +469,23 @@ Content-Digest: sha-256=:base64hash:
 
 {
   "action": "put",
-  "signature-agent": "https://abc123.platform.example/.well-known/signature-agent-card"
+  "signature-agent": "https://abc123.registry.example/.well-known/signature-agent-card"
 }
 ~~~
 
 ### Notification Processing {#notification-processing}
 
-Upon receiving a notification, the consumer MUST verify the HTTP Message
-Signature against the platform's key, discovered via the platform's
-`signature-agent` card. Notifications with missing or invalid signatures
-MUST be rejected.
+Upon receiving a notification, the client MUST verify the HTTP Message
+Signature against the registry operator's key, discovered via the registry
+operator's signature-agent card. Notifications with missing or invalid
+signatures MUST be rejected.
 
 A notification is advisory only. The registry endpoint remains the authoritative
-source of truth. After verifying a notification, consumers SHOULD re-fetch the
+source of truth. After verifying a notification, clients SHOULD re-fetch the
 affected signature agent card to obtain current metadata.
 
-Platforms SHOULD retry delivery of failed notifications with exponential
-backoff. Consumers that miss notifications will recover on their next
+Registry operators SHOULD retry delivery of failed notifications with
+exponential backoff. Clients that miss notifications will recover on their next
 conditional pull from the registry endpoint.
 
 # Security Considerations
@@ -495,18 +496,18 @@ Clients SHOULD reject cards with invalid signatures.
 ## Registry Integrity
 
 When a registry is served over HTTPS, TLS provides channel integrity between
-the server and the consumer. To additionally bind the registry contents to the
-platform's cryptographic identity, registry servers SHOULD sign their HTTP
-responses using {{HTTP-MESSAGE-SIGNATURES}} with a key present in the
-platform's own signature agent card. Consumers SHOULD verify such signatures
-when present.
+the server and the client. To additionally bind the registry contents to the
+registry operator's cryptographic identity, registry servers SHOULD sign their
+HTTP responses using {{HTTP-MESSAGE-SIGNATURES}} with a key present in the
+registry operator's own signature agent card. Clients SHOULD verify such
+signatures when present.
 
 ## Private Registries
 
 Registry endpoints that require authentication as described in
-{{registry-authentication}} limit exposure of a platform's customer list to
-authorized consumers only. Platforms SHOULD use authenticated registry
-endpoints when the enumeration of their customers is sensitive.
+{{registry-authentication}} limit exposure of registry entries to authorized
+clients only. Registry operators SHOULD use authenticated endpoints when the
+enumeration of their registry entries is sensitive.
 
 # Privacy Considerations
 
@@ -515,9 +516,8 @@ TODO
 ## Access Patterns
 
 Registry servers SHOULD avoid logging personally identifiable information from
-consumer requests. Consumers accessing a registry reveal their interest in the
-platform's registered agents; registry servers SHOULD treat access logs as
-sensitive.
+client requests. Clients fetching a registry reveal their interest in its
+entries; registry servers SHOULD treat access logs as sensitive.
 
 
 # IANA Considerations {#iana}

--- a/draft-meunier-webbotauth-registry.md
+++ b/draft-meunier-webbotauth-registry.md
@@ -119,6 +119,7 @@ This section describes Signature Agent Card, a JSON object containing parameters
   "rate-control": "429",
   "rate-expectation": "avg=10rps;max=100rps",
   "known-urls": ["/", "/robots.txt", "*.png"],
+  "signature_directory_url": "https://example.com/.well-known/http-message-signatures-directory",
   "keys": [{
     "kty": "OKP",
     "crv": "Ed25519",
@@ -277,6 +278,27 @@ Example
 * `["/favicon.ico"]`
 * `["/index.html"]`
 
+## Signature Directory URL {#signature-agent-parameter-signature-directory-url}
+
+The `signature_directory_url` parameter provides the URL of the signature agent's
+HTTP Message Signatures Directory as defined in {{DIRECTORY}}.
+
+When present, this parameter separates key material discovery from metadata
+discovery. Clients that need key material SHOULD fetch the directory at the
+given URL rather than relying on the `keys` parameter. This separation allows
+registry operators to host metadata and key material on different endpoints,
+supporting deployment scenarios where the registry endpoint itself contains
+signature agent card metadata but the key directory is hosted elsewhere.
+
+If both `signature_directory_url` and `keys` are present, the
+`signature_directory_url` takes precedence for key discovery.
+
+The URI scheme MUST be `https`.
+
+Example
+
+* `https://example.com/.well-known/http-message-signatures-directory`
+
 ## Keys {#signature-agent-parameter-keys}
 
 The `keys` parameter contains a JWKS as defined in {{Section 5 of JWK}}.
@@ -312,7 +334,7 @@ https://crawler2.example.com/.well-known/http-message-signatures-directory
 https://zerotrust-gateway.example.com/v1/signature-agent-card
 
 # Below is an inlined card with the data URL scheme
-data:application/json;,... # Invalid, not defined
+data:application/json,{"client_name":"Inline Bot","signature_directory_url":"https://inline.example.com/.well-known/http-message-signatures-directory"}
 ~~~
 
 ## Formal Syntax
@@ -780,6 +802,23 @@ in {{signature-agent-card}} in this registry.
 **Notes:**
 : N/A
 
+#### Signature Directory URL Parameter
+
+**Parameter Name:**
+: signature_directory_url
+
+**Parameter Description:**
+: URL of the signature agent's HTTP Message Signatures Directory for key discovery
+
+**Change Controller:**
+: IETF
+
+**Reference:**
+: {{signature-agent-parameter-signature-directory-url}}
+
+**Notes:**
+: N/A
+
 #### Keys Parameter
 
 **Parameter Name:**
@@ -821,6 +860,11 @@ The editor would also like to thank the following individuals (listed in alphabe
 
 # Changelog
 {:numbered="false"}
+
+v03
+
+- Add optional `signature_directory_url` parameter to separate key material from metadata
+- Fix inline data URL example in registry to use valid signature agent card
 
 v02
 


### PR DESCRIPTION
1 Rename "Public list" to "Registry Endpoint" given there's nothing mandating the format to be publicly exposed
2. Add a section about optional authentication
3. Discuss conditional GET (ETag/If-Modified-Since), and caching guidance
4. Add "Change Notification" section: registry operators MAY push signed POST notifications to registered callbacks on entry add/remove. Pull remains authoritative
5. Expand Security Considerations (registry integrity via Content-Digest + HTTP Message Signatures) and Privacy Considerations (access patterns)

fyi @punkeel @ulaskira 