### PR TITLE
[architecture] Add SSRF security considerations for Signature-Agent directory fetches

### DIFF
--- a/draft-meunier-web-bot-auth-architecture.md
+++ b/draft-meunier-web-bot-auth-architecture.md
@@ -44,6 +44,9 @@ normative:
 informative:
   OAUTH-BEARER: RFC6750
   RFC8446:
+  OWASP-SSRF:
+    title: OWASP Server-Side Request Forgery Prevention Cheat Sheet
+    target: https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html
 
 --- abstract
 
@@ -214,7 +217,7 @@ Agents SHOULD extend `@signature-parameters` defined in {{generating-http-messag
 `nonce`
 : base64url encoded random byte array. It is RECOMMENDED to use a 64-byte array.
 
-Client MUST ensure that this `nonce` is unique for the validity window of the signature, as defined by created and expires attributes.
+Agent MUST ensure that this `nonce` is unique for the validity window of the signature, as defined by created and expires attributes.
 
 ### Additional headers
 
@@ -278,7 +281,7 @@ Additional requirements are placed on this validation:
 
 Origin MAY require the `nonce` to satisfy certain constraints: be globally unique using a global nonce store, be unique to a specific location or time window using a local cache, or no constraint at all.
 
-## Key Distribution and Discovery
+## Key Distribution and Discovery {#key-distribution-and-discovery}
 
 This section describes the discovery mechanism for the agent directory.
 
@@ -342,7 +345,7 @@ Origins should account for the overhead of signature verification in their opera
 
 ## Nonce validation {#nonce-validation}
 
-Clients are the one controlling the nonce. While {{anti-replay}} mandates that clients MUST provide a globally unique nonce, it is the origin's responsibility to enforce it.
+The client controls the nonce. While {{anti-replay}} mandates that clients MUST provide a globally unique nonce, it is the origin's responsibility to enforce it.
 
 Different validation policies have different performance and operational considerations. Global uniqueness requires a global nonce store. Some origins may find that their use case can tolerate sharding on location, timing, or other properties.
 
@@ -419,6 +422,39 @@ Signature: sig2=:I1QWNzGXdP1a4dSvOHLCVOOanEYHDk+ZsVxM9MLX/p4ko69ghKwR5EOtAD96g7g
 
 `Signature` is unchanged as the base is similar. Both `Signature-Agent` and
 `Signature-Input` reflect the update from `sig2` to `sig3`.
+
+## Server-Side Request Forgery (SSRF)
+
+As described in {{key-distribution-and-discovery}}, verifiers may fetch key directories based on
+the URL value conveyed in `Signature-Agent` when included in a request. Since
+clients control the `Signature-Agent` header value, this introduces a risk of
+server-side request forgery (SSRF) attacks by malicious clients.
+
+Verifiers SHOULD take appropriate precautions as follows:
+
+`Response size`
+: a directory can be arbitrarily large. Verifiers SHOULD reject responses
+  exceeding a defined byte limit after content decoding.
+
+`Key count`
+: a JWKS with many keys forces O(n) key search. Verifiers SHOULD enforce
+  a maximum key count.
+
+`Fetch latency`
+: no timeout allows slowloris-style exhaustion. Verifiers SHOULD apply
+  a wall-clock timeout to directory fetches.
+
+`Redirect chains`
+: unbounded HTTP redirects can be used to amplify requests. Verifiers
+  SHOULD limit redirect depth.
+
+`Network address ranges`
+: no address filtering can target internal services. Verifiers SHOULD
+  prevent directory fetches to private, loopback, and link-local
+  address ranges.
+
+Further recommendations can be found in the Open Worldwide Application
+Security Project (OWASP) SSRF Prevention Cheat Sheet {{OWASP-SSRF}}.
 
 # Privacy Considerations
 
@@ -753,6 +789,7 @@ Tanya Verma.
 v05
 
 - Fix some typos
+- Add security considerations of Signature-Agent by origins if present
 
 v04
 

--- a/draft-meunier-web-bot-auth-architecture.md
+++ b/draft-meunier-web-bot-auth-architecture.md
@@ -69,7 +69,7 @@ themselves to origins for several reasons:
 Current identification methods such as IP allowlisting, User-Agent strings, or shared API keys have
 significant limitations in security, scalability, and manageability. This document defines an
 architecture enabling agents to cryptographically identify themselves using {{HTTP-MESSAGE-SIGNATURES}}.
-It proposes that every request from bots to be signed by a private key owned by its provider.
+It proposes that every request from bots be signed by a private key owned by its provider.
 This way, every origin can validate the service identity.
 
 # Motivation
@@ -93,7 +93,7 @@ monitor and rate limit per agent operator. However, these mechanisms have drawba
     history that needs to be carefully inspected and managed before purchase and
     use.
  3. An agent may go to every website on the Internet and share a secret with
-    them like a Bearer from  {{OAUTH-BEARER}}. This is impractical to scale for any
+    them like a Bearer from {{OAUTH-BEARER}}. This is impractical to scale for any
     agent beyond select partnerships, and insecure, as key rotation is challenging
     and becomes less secure as the consumers scale.
 
@@ -146,8 +146,7 @@ The following terms are used throughout this document:
 A User initiates an action requiring the Agent to perform an HTTP request.
 The Agent constructs the request, generates a signature using its signing key,
 and includes it in the request as defined in {{Section 3.1 of HTTP-MESSAGE-SIGNATURES}}
-along with the `Signature-Agent` header for discovery for its
-verification key.
+along with the `Signature-Agent` header for discovery of its verification key.
 Upon receiving the request, the Origin ensures it has the verification key for the Agent,
 validates the signature, and processes the request if the signature is valid.
 
@@ -277,8 +276,7 @@ Additional requirements are placed on this validation:
 - During step 5, the Origin MAY discard signatures for which they do not know the `keyid`.
 - During step 5, if the keyid is unknown to the origin, they MAY fetch the provider directory as indicated by `Signature-Agent` header defined in Section 4 of {{DIRECTORY}}.
 
-Origin MAY require the `nonce` to satisfy certain constraint: be globally unique using a global nonce store, be unique to a specific location or time window using a local cache, or not constraint at all.
-
+Origin MAY require the `nonce` to satisfy certain constraints: be globally unique using a global nonce store, be unique to a specific location or time window using a local cache, or no constraint at all.
 
 ## Key Distribution and Discovery
 
@@ -304,6 +302,7 @@ Example:
 
 
 ### Out-of-band communication between client and origin
+
 A service submitting their key to an origin, or the origin manually adding a service to their trusted list.
 
 ### Public list
@@ -420,7 +419,7 @@ Signature: sig2=:I1QWNzGXdP1a4dSvOHLCVOOanEYHDk+ZsVxM9MLX/p4ko69ghKwR5EOtAD96g7g
 
 `Signature` is unchanged as the base is similar. Both `Signature-Agent` and
 `Signature-Input` reflect the update from `sig2` to `sig3`.
-.
+
 # Privacy Considerations
 
 ## Public Identity
@@ -750,6 +749,10 @@ Tanya Verma.
 
 # Changelog
 {:numbered="false"}
+
+v05
+
+- Fix some typos
 
 v04
 

--- a/draft-meunier-web-bot-auth-architecture.md
+++ b/draft-meunier-web-bot-auth-architecture.md
@@ -217,7 +217,7 @@ Agents SHOULD extend `@signature-parameters` defined in {{generating-http-messag
 `nonce`
 : base64url encoded random byte array. It is RECOMMENDED to use a 64-byte array.
 
-Agent MUST ensure that this `nonce` is unique for the validity window of the signature, as defined by created and expires attributes.
+Client MUST ensure that this `nonce` is unique for the validity window of the signature, as defined by created and expires attributes.
 
 ### Additional headers
 
@@ -345,7 +345,7 @@ Origins should account for the overhead of signature verification in their opera
 
 ## Nonce validation {#nonce-validation}
 
-The client controls the nonce. While {{anti-replay}} mandates that clients MUST provide a globally unique nonce, it is the origin's responsibility to enforce it.
+Clients control the nonce. While {{anti-replay}} mandates that clients MUST provide a globally unique nonce, it is the origin's responsibility to enforce it.
 
 Different validation policies have different performance and operational considerations. Global uniqueness requires a global nonce store. Some origins may find that their use case can tolerate sharding on location, timing, or other properties.
 
@@ -788,8 +788,8 @@ Tanya Verma.
 
 v05
 
+- Add SSRF security considerations for Signature-Agent directory fetches
 - Fix some typos
-- Add security considerations of Signature-Agent by origins if present
 
 v04
 


### PR DESCRIPTION
- adds SSRF security considerations
- took what i thought was a nice list of precautions here by Thibault https://github.com/thibmeu/http-message-signatures-directory/issues/87 and formatted them
- added `network address ranges` to listed precautions
- added an OWASP SSRF cheat sheet reference and citation