### PR TITLE
add Identifiers and Trust Model section

### DIFF
--- a/draft-meunier-webbotauth-httpsig-directory.md
+++ b/draft-meunier-webbotauth-httpsig-directory.md
@@ -87,10 +87,10 @@ Together, these mechanisms enable key distribution and discovery for HTTP Messag
 The key directory is served as a JSON Web Key Set (JWKS) as defined in {{Section 5 of JWK}}.
 The "alg" parameter are restricted to algorithm registered against HTTP Signature Algorithms Section of {{HTTP-MESSAGE-SIGNATURES-IANA}}
 
-The directory SHOULD be served over HTTPS.
+The directory MUST be served over HTTPS.
 The directory MUST be served with media type `application/http-message-signatures-directory+json`.
 
-A client application SHOULD validate the directory format and reject malformed entries.
+A verifier SHOULD validate the directory format and reject malformed entries.
 
 # HTTP Method Context `Signature-Agent`
 
@@ -110,7 +110,7 @@ STRUCTURED-HEADERS}}. If the `type` parameter is absent, its value is `directory
 The following `type` values are defined:
 
 `directory`
-: The member value identifies an origin. A client resolves the HTTP Message
+: The member value identifies an origin. A verifier resolves the HTTP Message
 Signatures Directory using the well-known URI registered in {{wkuri-reg}} at
 that origin.
 
@@ -120,12 +120,12 @@ that origin.
 `cimd`
 : The member value identifies a Client ID Metadata Document {{CIMD}} URI.
 
-A client that does not support a `type` value MUST ignore that member.
-A client MUST NOT infer the discovery mechanism from the URI path, media type,
+A verifier that does not support a `type` value MUST ignore that member.
+A verifier MUST NOT infer the discovery mechanism from the URI path, media type,
 or response body.
 
-[[ Editor's note: strenghen requirements around jwks_uri and cimd. directory
-uses a signed well-knwon to guarantee {{security}} ]]
+[[ Editor's note: strengthen requirements around jwks_uri and cimd. directory
+uses a signed well-known to guarantee {{security}} ]]
 
 The URI scheme MUST be `https`.
 
@@ -140,14 +140,15 @@ ignored.
 
 ## Key rotation
 
-Clients SHOULD implement key rotation by including multiple keys in the directory
-with a different validity period. When rotating keys, clients SHOULD:
+Directory operators SHOULD implement key rotation by including multiple keys
+in the directory with a different validity period. When rotating keys,
+operators SHOULD:
 
 1. Add the new key to the directory before its intended use date
 2. Continue to include the old key until its expiration date
 3. Remove expired keys from the directory
 
-Servers SHOULD cache the directory contents and refresh upon expiration.
+Verifiers SHOULD cache the directory contents and refresh upon expiration.
 
 Removing a key from the directory deactivates it. Verifiers stop accepting keys
 once their cached copy expires. The directory's cache lifetime therefore bounds
@@ -158,7 +159,7 @@ how long a removed key keeps verifying.
 ## Binding keys to the directory authority
 
 To ensure the authenticity and integrity of the key material provided by the
-directory, clients **SHOULD** validate the directory's response.
+directory, verifiers SHOULD validate the directory's response.
 
 It is RECOMMENDED that a directory server construct and include one HTTP
 Message Signature per key with the response, as defined in
@@ -191,13 +192,12 @@ Directory server SHOULD include the following `@signature-params` as defined in
 `tag`
 : MUST be `http-message-signatures-directory`
 
-Clients SHOULD validate these signatures using the keys provided by the
-directory. Clients SHOULD validate the `Content-Digest` field against the
-response body. Clients SHOULD ignore keys from a directory response that do not
-have a corresponding valid signature. This validation checks the integrity of the
-key set and binds it to the intended authority.
-
-[[ Editor's note: consider using MUST here ]]
+Verifiers relying on the domain binding MUST validate these signatures
+using the keys provided by the directory, validate the `Content-Digest`
+field against the response body, and ignore keys that do not have a
+corresponding valid signature. Verifiers using keys opaquely MAY skip this
+validation, in which case they obtain no binding. This validation checks
+the integrity of the key set and binds it to the intended authority.
 
 # Privacy Considerations
 
@@ -382,15 +382,8 @@ Lucas Pardue.
 
 draft-meunier-webbotauth-httpsig-directory-01
 
-- Clarify what directory response signatures establish: proof of possession
-  and protection against re-hosting, not authority over the domain, which
-  comes from TLS alone.
-- Delegation and chaining are out of scope. Remove the `x5c`, AIA, and `x5u`
-  examples (previously "experimental").
-- Remove the `http` and `data` URI schemes for `Signature-Agent`. Discovery
-  uses `https` only, and the inline directory example is gone with it.
-- State that removing a key from the directory deactivates it once verifier
-  caches expire, so the cache lifetime bounds deactivation.
+- Tighten the domain binding: `https` only, MUST validate when relying on it.
+- Remove delegation examples; use verifier and directory operator role terms.
 
 draft-meunier-webbotauth-httpsig-directory-00
 

--- a/draft-meunier-webbotauth-httpsig-directory.md
+++ b/draft-meunier-webbotauth-httpsig-directory.md
@@ -113,7 +113,7 @@ STRUCTURED-HEADERS}}. If the `type` parameter is absent, its value is `directory
 The following `type` values are defined:
 
 `directory`
-: The member value identifies an origin. For `http` and `https` URI values, a
+: The member value identifies an origin. For `https` URI values, a
 client resolves the HTTP Message Signatures Directory using the well-known URI
 registered in {{wkuri-reg}} at that origin. For `data` URI values, the member
 value contains an inline HTTP Message Signatures Directory.
@@ -131,7 +131,6 @@ or response body.
 The URI scheme MUST be one of:
 
 - **https (RECOMMENDED)**: Points to an HTTPS resource
-- **http**: Points to an HTTP resource
 - **data**: Contains inline key material
 
 When using the `data` URI scheme with `type=directory`, the media type MUST be
@@ -160,10 +159,13 @@ Servers SHOULD cache the directory contents and refresh upon expiration.
 To ensure the authenticity and integrity of the key material provided by the
 directory, clients **SHOULD** validate the directory's response.
 
-When a directory server provides a key directory over HTTP or HTTPS, it is
-RECOMMENDED that it constructs and includes one HTTP Message Signatures per keys
+When a directory server provides a key directory over HTTPS, it is
+RECOMMENDED that it construct and include one HTTP Message Signature per key
 with the response, as defined in {{HTTP-MESSAGE-SIGNATURES}}.
-Each key SHOULD be used to provide one signature.
+Each key SHOULD be used to provide one signature. These signatures prove
+possession of the advertised keys and, by covering `@authority`, prevent the
+key set from being re-served under a different authority. They do not confer
+authority over the serving domain: that comes from the TLS connection alone.
 
 Directory server SHOULD include the following covered components:
 
@@ -338,9 +340,11 @@ Cache-Control: max-age=86400
 
 ## Delegation and chaining
 
-There are multiple methods to perform delegation and chaining. There are no specific methods
-that have been favored by implementation so far, should they even support them.
-It is adviced to consider delegation as experimental for now, and provide input on the associated
+Delegation and chaining are out of scope for this document and are expected
+to be specified separately. The examples below are informative only: they
+illustrate how existing JWK fields (`x5c`, `x5u`, AIA) could carry a
+delegation, without defining verifier behaviour. Input is welcome on the
+associated
 [GitHub issue](https://github.com/thibmeu/http-message-signatures-directory/issues/27).
 
 ### Key Directory on sub.example.com with a delegation from example.com via x5c full certificate chain
@@ -486,6 +490,14 @@ Lucas Pardue.
 
 # Changelog
 {:numbered="false"}
+
+draft-meunier-webbotauth-httpsig-directory-01
+
+- Clarify what directory response signatures establish: proof of possession
+  and protection against re-hosting, not authority over the domain, which
+  comes from TLS alone.
+- Delegation and chaining are explicitly out of scope; the examples are
+  informative only (previously "experimental").
 
 draft-meunier-webbotauth-httpsig-directory-00
 

--- a/draft-meunier-webbotauth-httpsig-directory.md
+++ b/draft-meunier-webbotauth-httpsig-directory.md
@@ -49,9 +49,6 @@ normative:
     target: https://www.iana.org/assignments/well-known-uris/well-known-uris.xhtml
 
 informative:
-  BASE64: RFC2397
-  CRYPTO-TEST-KEYS: RFC9500
-  X509-PKI: RFC5280
 
 
 --- abstract
@@ -113,10 +110,9 @@ STRUCTURED-HEADERS}}. If the `type` parameter is absent, its value is `directory
 The following `type` values are defined:
 
 `directory`
-: The member value identifies an origin. For `https` URI values, a
-client resolves the HTTP Message Signatures Directory using the well-known URI
-registered in {{wkuri-reg}} at that origin. For `data` URI values, the member
-value contains an inline HTTP Message Signatures Directory.
+: The member value identifies an origin. A client resolves the HTTP Message
+Signatures Directory using the well-known URI registered in {{wkuri-reg}} at
+that origin.
 
 `jwks_uri`
 : The member value identifies a JWK Set URI.
@@ -128,15 +124,14 @@ A client that does not support a `type` value MUST ignore that member.
 A client MUST NOT infer the discovery mechanism from the URI path, media type,
 or response body.
 
-The URI scheme MUST be one of:
+[[ Editor's note: strenghen requirements around jwks_uri and cimd. directory
+uses a signed well-knwon to guarantee {{security}} ]]
 
-- **https (RECOMMENDED)**: Points to an HTTPS resource
-- **data**: Contains inline key material
+The URI scheme MUST be `https`.
 
-When using the `data` URI scheme with `type=directory`, the media type MUST be
-`application/http-message-signatures-directory+json`. The content MAY be base64 encoded
-as per {{BASE64}}.
-The `data` URI scheme MUST NOT be used with other `type` values.
+[[ Editor's note: earlier versions also allowed `http` and `data` URI
+schemes. A `data` URI carries inline key material with no authority behind
+it, which muddied what the directory binding proves. Both are removed for now. ]]
 
 If dictionary values are not valid URI-references, the entire header field MAY be
 ignored.
@@ -154,14 +149,20 @@ with a different validity period. When rotating keys, clients SHOULD:
 
 Servers SHOULD cache the directory contents and refresh upon expiration.
 
+Removing a key from the directory deactivates it. Verifiers stop accepting keys
+once their cached copy expires. The directory's cache lifetime therefore bounds
+how long a removed key keeps verifying.
+
+[[ Editor's note: Recommendation around lifetime? ]]
+
 ## Binding keys to the directory authority
 
 To ensure the authenticity and integrity of the key material provided by the
 directory, clients **SHOULD** validate the directory's response.
 
-When a directory server provides a key directory over HTTPS, it is
-RECOMMENDED that it construct and include one HTTP Message Signature per key
-with the response, as defined in {{HTTP-MESSAGE-SIGNATURES}}.
+It is RECOMMENDED that a directory server construct and include one HTTP
+Message Signature per key with the response, as defined in
+{{HTTP-MESSAGE-SIGNATURES}}.
 Each key SHOULD be used to provide one signature. These signatures prove
 possession of the advertised keys and, by covering `@authority`, prevent the
 key set from being re-served under a different authority. They do not confer
@@ -195,6 +196,8 @@ directory. Clients SHOULD validate the `Content-Digest` field against the
 response body. Clients SHOULD ignore keys from a directory response that do not
 have a corresponding valid signature. This validation checks the integrity of the
 key set and binds it to the intended authority.
+
+[[ Editor's note: consider using MUST here ]]
 
 # Privacy Considerations
 
@@ -341,111 +344,13 @@ Cache-Control: max-age=86400
 ## Delegation and chaining
 
 Delegation and chaining are out of scope for this document and are expected
-to be specified separately. The examples below are informative only: they
-illustrate how existing JWK fields (`x5c`, `x5u`, AIA) could carry a
-delegation, without defining verifier behaviour. Input is welcome on the
-associated
+to be specified separately. Input is welcome on the associated
 [GitHub issue](https://github.com/thibmeu/http-message-signatures-directory/issues/27).
 
-### Key Directory on sub.example.com with a delegation from example.com via x5c full certificate chain
-
-In this example, example.com key is testECCP256 provided in {{Section 2.3 of CRYPTO-TEST-KEYS}}.
-Certificate chain is passed via x5c key parameter defined in {{Section 4.7 of JWK}}.
-
-~~~
-GET /.well-known/http-message-signatures-directory HTTP/1.1
-Host: sub.example.com
-Accept: application/http-message-signatures-directory
-
-HTTP/1.1 200 OK
-Content-Type: application/http-message-signatures-directory
-Cache-Control: max-age=86400
-{
-  "keys": [{
-    "kty": "OKP",
-    "crv": "Ed25519",
-    "kid": "NFcWBst6DXG-N35nHdzMrioWntdzNZghQSkjHNMMSjw",
-    "x": "JrQLj5P_89iXES9-vFgrIy29clF9CC_oPPsw3c5D0bs",
-    "use": "sig",
-    "nbf": 1712793600,
-    "exp": 1715385600,
-    "x5c": [
-      "MIIBYTCCAQagAwIBAgIUFDXRG3pgZ6txehQO2LT4aCqI3f0wCgYIKoZIzj0EAwIwFjEUMBIGA1UEAwwLZXhhbXBsZS5jb20wHhcNMjUwNjEzMTA0MjQxWhcNMzUwNjExMTA0MjQxWjAaMRgwFgYDVQQDDA9zdWIuZXhhbXBsZS5jb20wKjAFBgMrZXADIQAmtAuPk//z2JcRL368WCsjLb1yUX0IL+g8+zDdzkPRu6NdMFswCQYDVR0TBAIwADAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0OBBYEFKV3qaYNFbzQB1QmN4sa13+t4RmoMB8GA1UdIwQYMBaAFFtwp5gX95/2N9L349xEbCEJ17vUMAoGCCqGSM49BAMCA0kAMEYCIQC8r+GvvNnjI+zzOEDMOM/g9e8QLm00IZXP+tjDqah1UQIhAJHffLke9iEP1pUdm+oRLrq6bUqyLELi5TH2t+BaagKv",
-      "MIIBcDCCARagAwIBAgIUS502rlCXxG2vviltGdfe3fmX4pIwCgYIKoZIzj0EAwIwFjEUMBIGA1UEAwwLZXhhbXBsZS5jb20wHhcNMjUwNjEzMTA0MTQzWhcNMzUwNjExMTA0MTQzWjAWMRQwEgYDVQQDDAtleGFtcGxlLmNvbTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABEIlSPiPt4L/teyjdERSxyoeVY+9b3O+XkjpMjLMRcWxbEzRDEy41bihcTnpSILImSVymTQl9BQZq36QpCpJQnKjQjBAMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgIEMB0GA1UdDgQWBBRbcKeYF/ef9jfS9+PcRGwhCde71DAKBggqhkjOPQQDAgNIADBFAiEAwTOqm1zNAvZuQ8Zb5AftQIZotq4Xe6GHz3+nJ04ybgoCIEEZtn1Pa+GCbmbWh12piHJBKh09TCA0feTedisbwzPV"
-    ]
-  }]
-}
-~~~
-
-### Key Directory on sub.example.com with a delegation from example.com via a leaf certificate and AIA field
-
-In this example, example.com key is testECCP256 provided in {{Section 2.3 of CRYPTO-TEST-KEYS}}.
-Certificate chain is passed via x5c key parameter defined in {{Section 4.7 of JWK}},
-and the root certificate is signaled by the presence of an Authority Information Access extension
-as defined in {{Section 5.2.7 of X509-PKI}}.
-
-~~~
-GET /.well-known/http-message-signatures-directory HTTP/1.1
-Host: sub.example.com
-Accept: application/http-message-signatures-directory
-
-HTTP/1.1 200 OK
-Content-Type: application/http-message-signatures-directory
-Cache-Control: max-age=86400
-{
-  "keys": [{
-    "kty": "OKP",
-    "crv": "Ed25519",
-    "kid": "NFcWBst6DXG-N35nHdzMrioWntdzNZghQSkjHNMMSjw",
-    "x": "JrQLj5P_89iXES9-vFgrIy29clF9CC_oPPsw3c5D0bs",
-    "use": "sig",
-    "nbf": 1712793600,
-    "exp": 1715385600,
-    "x5c": [
-      "MIIBYTCCAQagAwIBAgIUFDXRG3pgZ6txehQO2LT4aCqI3f0wCgYIKoZIzj0EAwIwFjEUMBIGA1UEAwwLZXhhbXBsZS5jb20wHhcNMjUwNjEzMTA0MjQxWhcNMzUwNjExMTA0MjQxWjAaMRgwFgYDVQQDDA9zdWIuZXhhbXBsZS5jb20wKjAFBgMrZXADIQAmtAuPk//z2JcRL368WCsjLb1yUX0IL+g8+zDdzkPRu6NdMFswCQYDVR0TBAIwADAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0OBBYEFKV3qaYNFbzQB1QmN4sa13+t4RmoMB8GA1UdIwQYMBaAFFtwp5gX95/2N9L349xEbCEJ17vUMAoGCCqGSM49BAMCA0kAMEYCIQC8r+GvvNnjI+zzOEDMOM/g9e8QLm00IZXP+tjDqah1UQIhAJHffLke9iEP1pUdm+oRLrq6bUqyLELi5TH2t+BaagKv"
-    ]
-  }]
-}
-~~~
-
-The AIA extension is as follow
-
-~~~
-X509v3 extensions:
-  Authority Information Access:
-    CA Issuers - URI:https://example.com/.well-known/http-message-signatures-directory.crt
-~~~
-
-The verifier should validate the signature with the public key in the Signature-Agent,
-match the public key with the leaf cert, then fetch the root cert from the AIA URI and verify the leaf cert with it.
-
-### Key Directory on sub.example.com with a delegation from example.com via x5u field
-
-Leveraging x5c imposes that a PEM encoded certificate is present in the returned JWKS.
-If size is a constraint, or deployment imposes a more dynamic certificate management,
-directory server may use x5u key parameter defined in {{Section 4.6 of JWK}}.
-
-~~~
-GET /.well-known/http-message-signatures-directory HTTP/1.1
-Host: sub.example.com
-Accept: application/http-message-signatures-directory
-
-HTTP/1.1 200 OK
-Content-Type: application/http-message-signatures-directory
-Cache-Control: max-age=86400
-
-{
-  "keys": [{
-    "kty": "OKP",
-    "crv": "Ed25519",
-    "kid": "NFcWBst6DXG-N35nHdzMrioWntdzNZghQSkjHNMMSjw",
-    "x": "JrQLj5P_89iXES9-vFgrIy29clF9CC_oPPsw3c5D0bs",
-    "use": "sig",
-    "nbf": 1712793600,
-    "exp": 1715385600,
-    "x5u": "https://example.com/.well-known/http-message-signature-chain/sub.example.com.crt"
-}
-~~~
+[[ Editor's note: earlier versions carried informative delegation examples
+using `x5c`, AIA, and `x5u`. They suggested verifier behaviour this document
+does not define, so they are removed for clarity purposes. Issue 27 tracks
+a possible separate document. ]]
 
 ## Request with HTTP Signature-Agent
 
@@ -455,22 +360,6 @@ This extend the examples from {{Appendix B of HTTP-MESSAGE-SIGNATURES}}.
 POST /foo?param=Value&Pet=dog HTTP/1.1
 Host: example.com
 Signature-Agent: my_test="https://directory.test";type=directory
-{"hello": "world"}
-
-HTTP/1.1 200 OK
-{"message": "good dog"}
-~~~
-
-## Request with `data` URI Signature-Agent
-
-A Signature-Agent using `data` URI can be used to communicate an ephemeral keys, as long as there is a chain to a certificate trusted by the origin.
-
-In this example, the directory is signed by `example.com`. The CA is self-signed, even though it MAY be part of an existing PKI.
-
-~~~
-POST /foo?param=Value&Pet=dog HTTP/1.1
-Host: example.com
-Signature-Agent: my_test="data:application/http-message-signatures-directory;utf8,{\"keys\":[{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"kid\":\"NFcWBst6DXG-N35nHdzMrioWntdzNZghQSkjHNMMSjw\",\"x\":\"JrQLj5P_89iXES9-vFgrIy29clF9CC_oPPsw3c5D0bs\",\"use\":\"sig\",\"nbf\":1712793600,\"exp\":1715385600,\"x5c\":[\"MIIBYTCCAQagAwIBAgIUFDXRG3pgZ6txehQO2LT4aCqI3f0wCgYIKoZIzj0EAwIwFjEUMBIGA1UEAwwLZXhhbXBsZS5jb20wHhcNMjUwNjEzMTA0MjQxWhcNMzUwNjExMTA0MjQxWjAaMRgwFgYDVQQDDA9zdWIuZXhhbXBsZS5jb20wKjAFBgMrZXADIQAmtAuPk//z2JcRL368WCsjLb1yUX0IL+g8+zDdzkPRu6NdMFswCQYDVR0TBAIwADAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0OBBYEFKV3qaYNFbzQB1QmN4sa13+t4RmoMB8GA1UdIwQYMBaAFFtwp5gX95/2N9L349xEbCEJ17vUMAoGCCqGSM49BAMCA0kAMEYCIQC8r+GvvNnjI+zzOEDMOM/g9e8QLm00IZXP+tjDqah1UQIhAJHffLke9iEP1pUdm+oRLrq6bUqyLELi5TH2t+BaagKv\",\"MIIBcDCCARagAwIBAgIUS502rlCXxG2vviltGdfe3fmX4pIwCgYIKoZIzj0EAwIwFjEUMBIGA1UEAwwLZXhhbXBsZS5jb20wHhcNMjUwNjEzMTA0MTQzWhcNMzUwNjExMTA0MTQzWjAWMRQwEgYDVQQDDAtleGFtcGxlLmNvbTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABEIlSPiPt4L/teyjdERSxyoeVY+9b3O+XkjpMjLMRcWxbEzRDEy41bihcTnpSILImSVymTQl9BQZq36QpCpJQnKjQjBAMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgIEMB0GA1UdDgQWBBRbcKeYF/ef9jfS9+PcRGwhCde71DAKBggqhkjOPQQDAgNIADBFAiEAwTOqm1zNAvZuQ8Zb5AftQIZotq4Xe6GHz3+nJ04ybgoCIEEZtn1Pa+GCbmbWh12piHJBKh09TCA0feTedisbwzPV\"]}]}"
 {"hello": "world"}
 
 HTTP/1.1 200 OK
@@ -496,8 +385,12 @@ draft-meunier-webbotauth-httpsig-directory-01
 - Clarify what directory response signatures establish: proof of possession
   and protection against re-hosting, not authority over the domain, which
   comes from TLS alone.
-- Delegation and chaining are explicitly out of scope; the examples are
-  informative only (previously "experimental").
+- Delegation and chaining are out of scope. Remove the `x5c`, AIA, and `x5u`
+  examples (previously "experimental").
+- Remove the `http` and `data` URI schemes for `Signature-Agent`. Discovery
+  uses `https` only, and the inline directory example is gone with it.
+- State that removing a key from the directory deactivates it once verifier
+  caches expire, so the cache lifetime bounds deactivation.
 
 draft-meunier-webbotauth-httpsig-directory-00
 

--- a/draft-meunier-webbotauth-httpsig-directory.md
+++ b/draft-meunier-webbotauth-httpsig-directory.md
@@ -169,7 +169,7 @@ possession of the advertised keys and, by covering `@authority`, prevent the
 key set from being re-served under a different authority. They do not confer
 authority over the serving domain: that comes from the TLS connection alone.
 
-Directory server SHOULD include the following covered components:
+Directory server MUST include the following covered components:
 
 `@authority`
 : as defined in {{Section 2.2.3 of HTTP-MESSAGE-SIGNATURES}}. `req` flag defined in {{Section 2.4 of HTTP-MESSAGE-SIGNATURES}} MUST be set.

--- a/draft-meunier-webbotauth-httpsig-protocol.md
+++ b/draft-meunier-webbotauth-httpsig-protocol.md
@@ -152,8 +152,8 @@ addresses and User-Agent today.
 Unlike an IP address, a key is cheap to mint: an Agent blocked on its `keyid`
 can rotate its key or stop sending signatures altogether. The protocol does
 not try to prevent this. It targets honest clients that want to be
-recognised across requests. An Agent that does not participate falls back to the origin's existing
-bot-management path.
+recognised across requests. Unsigned requests are out of scope. This
+document does not define or change how origins treat them.
 
 A valid signature proves two things: the request was produced by a holder of
 the private key ({{anti-replay}} bounds reuse), and requests with the same

--- a/draft-meunier-webbotauth-httpsig-protocol.md
+++ b/draft-meunier-webbotauth-httpsig-protocol.md
@@ -50,6 +50,7 @@ informative:
     title: OWASP Server-Side Request Forgery Prevention Cheat Sheet
     target: https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html
   SIGNATURE-KEY: I-D.draft-hardt-httpbis-signature-key
+  WELLKNOWN-URI: RFC8615
 
 --- abstract
 
@@ -142,20 +143,22 @@ verifier can conclude from a valid signature.
 
 ## The key is the identity {#key-is-identity}
 
-In this draft, an Agent's identity is its signing key. The `keyid` defined in
+In this draft, an Agent's base identity is its signing key. {{origin-binding}}
+defines a domain binding that can extend it. The `keyid` defined in
 {{generating-http-message-signature}} is a normalised thumbprint of that key. Origins
 can log, rate limit, allowlist, or block a `keyid` the way they do IP
 addresses and User-Agent today.
 
 Unlike an IP address, a key is cheap to mint: an Agent blocked on its `keyid`
 can rotate its key or stop sending signatures altogether. The protocol does
-not try to prevent this. It targets honest clients that want to accrue
-trust. An Agent that does not participate falls back to the origin's existing
+not try to prevent this. It targets honest clients that want to be
+recognised across requests. An Agent that does not participate falls back to the origin's existing
 bot-management path.
 
 A valid signature proves two things: the request was produced by a holder of
 the private key, and requests with the same `keyid` come from holders of the
-same key. This is enough for an origin to build trust for a `keyid`. It
+same key. This is enough for an origin to recognise a `keyid` and attach
+policy to it. It
 does not say who operates the Agent, whether the Agent is benign, or whether
 the request is authorized. Those are origin policy.
 
@@ -172,7 +175,7 @@ does not change what a valid signature proves.
 
 `Signature-Agent` is a client-controlled hint. Verifiers MUST NOT grant
 trust based on its value alone. They can use it to triage requests, but
-trust is attached to the verified key, or to a verified binding
+policy attaches to the verified key, or to a verified binding
 ({{origin-binding}}).
 
 Discovery is required for key updates (addition, removal). It is bounded by the
@@ -185,25 +188,34 @@ comes from the well-known directory defined in {{DIRECTORY}}, the verifier
 additionally learns which domain publishes the key. The TLS connection
 authenticates the domain serving the directory, and each advertised key signs
 the directory response, proving possession and preventing the key set from
-being re-served under a different authority (Section 5.2 of {{DIRECTORY}}).
+being re-served under a different authority (see "Binding keys to the
+directory authority" in {{DIRECTORY}}).
 These signatures do not confer authority over the domain: that comes from the
-TLS connection alone.
+TLS connection alone. The binding is not exclusive: several domains may
+publish the same key. It attaches to the (key, domain) pair the verifier
+validated.
 
-This protocol supports two modes. In the first, the key alone is the
-identity. An Agent needs nothing more than a keypair, and there is no
-rotation: a new key is a new identity, and trust starts over. In the
-second, the identity is a domain name. The Agent MUST publish its keys in
-the directory defined in {{DIRECTORY}}, and a verifier relying on the
-domain MUST validate the binding described above. This mode supports
-rotation: the directory serves the old and the new key together, and
-removing a key deactivates it once caches expire. It also gives verifiers
-a name to attach information to, which persists trust across rotation.
+This protocol supports two modes. Both use the same wire format: nothing
+in a request signals a mode, and the verifier chooses what to rely on.
+In the opaque mode, the key alone is the identity. An Agent needs nothing
+more than a keypair. This document defines no rotation for this mode: a
+new key is a new identity, though a future mechanism may provide rotation.
+In the domain binding mode, the identity is a domain name. The binding
+exists only for keys published in the directory defined in {{DIRECTORY}}:
+an Agent exposes its domain to verifiers by publishing its keys there.
+A verifier relying on the domain MUST validate the binding described
+above. A verifier using keys opaquely
+MAY skip that validation, in which case it obtains no binding. Domain
+binding supports rotation: the directory serves the old and the new key
+together, and removing a key deactivates it once caches expire. It also
+gives verifiers a name to attach information to, which persists across
+rotation.
 
 [[ Editor's note: the two-mode split follows the July 2026 list discussion.
 https://mailarchive.ietf.org/arch/msg/web-bot-auth/IZ0Ie47iydtlC1laaJcxxxR3VW8/
 The MUST on directory binding is new. Previous versions said MAY mostly as
 the main mode was key alone and binding was an optional layer.
-Depending of how the group discusses the two modes, that wording is subject
+Depending on how the group discusses the two modes, that wording is subject
 to change ]]
 
 ## Out of scope
@@ -402,6 +414,14 @@ in {{DIRECTORY}}. This is the default when no `type` parameter is present.
 `cimd`
 : Resolve the member value as a Client ID Metadata Document {{CIMD}} URI. The
 document then provides key material through `jwks` or `jwks_uri`.
+
+Only the `directory` type establishes the domain binding in
+{{origin-binding}}. `jwks_uri` and `cimd` point to an arbitrary URL: TLS
+authenticates the host, not the path, no possession proof ties the
+keys to the URL, and nothing reserves the path to the origin's operator
+the way a {{WELLKNOWN-URI}} does. These types operate in the opaque mode. Trust attaches
+to the key ({{discovery-is-not-trust}}), not the URL, and a key change is
+an identity change.
 
 For all types, the key is selected using the `keyid` parameter in
 `Signature-Input`.
@@ -1107,16 +1127,8 @@ Tanya Verma.
 
 draft-meunier-webbotauth-httpsig-protocol-01
 
-- Add an Identity and Trust Model section: the key is the identity, discovery
-  confers no trust, and the protocol supports two modes. With a key alone,
-  an Agent needs nothing more than a keypair and there is no rotation. When
-  the identity is a domain name, the directory binding (TLS and proof of
-  possession) is a MUST, and rotation works by serving old and new keys
-  together. Blocking on `keyid` is best-effort by design. The protocol
-  targets honest clients accruing trust. Verifiers MUST NOT grant trust on
-  the `Signature-Agent` value alone. No wire format change.
-- Describe the document as a protocol throughout, matching the draft name
-  (was: architecture).
+- Add an Identity and Trust Model section: opaque and domain binding modes.
+- Describe the document as a protocol throughout (was: architecture).
 
 draft-meunier-webbotauth-httpsig-protocol-00
 

--- a/draft-meunier-webbotauth-httpsig-protocol.md
+++ b/draft-meunier-webbotauth-httpsig-protocol.md
@@ -148,8 +148,8 @@ can log, rate limit, allowlist, or block a `keyid` the way they do IP
 addresses and User-Agent today.
 
 Unlike an IP address, a key is cheap to mint: an Agent blocked on its `keyid`
-can rotate its key or stop sending signatures altogether. This is acceptable
-and out of scope. The protocol targets honest clients that want to accrue
+can rotate its key or stop sending signatures altogether. The protocol does
+not try to prevent this. It targets honest clients that want to accrue
 trust. An Agent that does not participate falls back to the origin's existing
 bot-management path.
 
@@ -170,8 +170,8 @@ The verifier needs the public key of the client they are validating.
 exchange, public lists, or the `Signature-Agent` header. The distribution method
 does not change what a valid signature proves.
 
-`Signature-Agent` is a client-controlled hint. Verifiers SHOULD NOT grant
-trust based on its value alone. This header can be used to triage requests, but
+`Signature-Agent` is a client-controlled hint. Verifiers MUST NOT grant
+trust based on its value alone. They can use it to triage requests, but
 trust is attached to the verified key, or to a verified binding
 ({{origin-binding}}).
 
@@ -189,8 +189,22 @@ being re-served under a different authority (Section 5.2 of {{DIRECTORY}}).
 These signatures do not confer authority over the domain: that comes from the
 TLS connection alone.
 
-In this document, such a binding is optional. Origins MAY use it for
-accountability or to persist trust across key rotation.
+This protocol supports two modes. In the first, the key alone is the
+identity. An Agent needs nothing more than a keypair, and there is no
+rotation: a new key is a new identity, and trust starts over. In the
+second, the identity is a domain name. The Agent MUST publish its keys in
+the directory defined in {{DIRECTORY}}, and a verifier relying on the
+domain MUST validate the binding described above. This mode supports
+rotation: the directory serves the old and the new key together, and
+removing a key deactivates it once caches expire. It also gives verifiers
+a name to attach information to, which persists trust across rotation.
+
+[[ Editor's note: the two-mode split follows the July 2026 list discussion.
+https://mailarchive.ietf.org/arch/msg/web-bot-auth/IZ0Ie47iydtlC1laaJcxxxR3VW8/
+The MUST on directory binding is new. Previous versions said MAY mostly as
+the main mode was key alone and binding was an optional layer.
+Depending of how the group discusses the two modes, that wording is subject
+to change ]]
 
 ## Out of scope
 
@@ -1094,11 +1108,13 @@ Tanya Verma.
 draft-meunier-webbotauth-httpsig-protocol-01
 
 - Add an Identity and Trust Model section: the key is the identity, discovery
-  confers no trust, and the directory binding to a Web origin is an optional
-  layer that persists trust across key rotation. Blocking on `keyid` is
-  best-effort by design; the protocol targets honest clients accruing trust.
-  Verifiers MUST NOT grant trust on the `Signature-Agent` value alone. No wire
-  format change.
+  confers no trust, and the protocol supports two modes. With a key alone,
+  an Agent needs nothing more than a keypair and there is no rotation. When
+  the identity is a domain name, the directory binding (TLS and proof of
+  possession) is a MUST, and rotation works by serving old and new keys
+  together. Blocking on `keyid` is best-effort by design. The protocol
+  targets honest clients accruing trust. Verifiers MUST NOT grant trust on
+  the `Signature-Agent` value alone. No wire format change.
 - Describe the document as a protocol throughout, matching the draft name
   (was: architecture).
 

--- a/draft-meunier-webbotauth-httpsig-protocol.md
+++ b/draft-meunier-webbotauth-httpsig-protocol.md
@@ -156,8 +156,8 @@ recognised across requests. An Agent that does not participate falls back to the
 bot-management path.
 
 A valid signature proves two things: the request was produced by a holder of
-the private key, and requests with the same `keyid` come from holders of the
-same key. This is enough for an origin to recognise a `keyid` and attach
+the private key ({{anti-replay}} bounds reuse), and requests with the same
+`keyid` come from holders of the same key. This is enough for an origin to recognise a `keyid` and attach
 policy to it. It
 does not say who operates the Agent, whether the Agent is benign, or whether
 the request is authorized. Those are origin policy.
@@ -419,9 +419,9 @@ Only the `directory` type establishes the domain binding in
 {{origin-binding}}. `jwks_uri` and `cimd` point to an arbitrary URL: TLS
 authenticates the host, not the path, no possession proof ties the
 keys to the URL, and nothing reserves the path to the origin's operator
-the way a {{WELLKNOWN-URI}} does. These types operate in the opaque mode. Trust attaches
-to the key ({{discovery-is-not-trust}}), not the URL, and a key change is
-an identity change.
+the way a {{WELLKNOWN-URI}} does. Under this protocol, these types provide
+an opaque value: trust attaches to that value and the keys it resolves to
+({{discovery-is-not-trust}}), and this document defines no binding for it.
 
 For all types, the key is selected using the `keyid` parameter in
 `Signature-Input`.

--- a/draft-meunier-webbotauth-httpsig-protocol.md
+++ b/draft-meunier-webbotauth-httpsig-protocol.md
@@ -77,8 +77,8 @@ Current identification methods such as IP allowlisting, User-Agent strings, or s
 significant limitations in security, scalability, and manageability. This document defines a
 protocol enabling agents to cryptographically identify themselves using {{HTTP-MESSAGE-SIGNATURES}}.
 It proposes that every request from bots be signed by a private key owned by its provider.
-This way, every origin can validate the service identity. {{trust-model}}
-defines what that identity is and what validation it establishes.
+This way, every origin can validate the service identifier. {{trust-model}}
+defines what that identifier is and what validation it establishes.
 
 # Motivation
 
@@ -136,12 +136,12 @@ The following terms are used throughout this document:
 **Origin**
 : An HTTP server receiving signed requests that implements the HTTP protocol and verifies {{HTTP-MESSAGE-SIGNATURES}} signatures. It acts as a verifier of the signature as defined by {{HTTP-MESSAGE-SIGNATURES}}.
 
-# Identity and Trust Model {#trust-model}
+# Identifiers and Trust Model {#trust-model}
 
 This section defines the identifiers produced by this protocol and what a
 verifier can conclude from a valid signature.
 
-## The signing key provides continuity {#key-is-identity}
+## The signing key provides continuity {#key-is-identifier}
 
 In this draft, an Agent's signing key is its base identifier. {{origin-binding}}
 defines a domain binding a verifier can establish. The `keyid` defined in
@@ -1127,7 +1127,7 @@ Tanya Verma.
 
 draft-meunier-webbotauth-httpsig-protocol-01
 
-- Add an Identity and Trust Model section: opaque and domain binding modes.
+- Add an Identifiers and Trust Model section: opaque and domain binding modes.
 - Describe the document as a protocol throughout (was: architecture).
 
 draft-meunier-webbotauth-httpsig-protocol-00

--- a/draft-meunier-webbotauth-httpsig-protocol.md
+++ b/draft-meunier-webbotauth-httpsig-protocol.md
@@ -138,13 +138,13 @@ The following terms are used throughout this document:
 
 # Identity and Trust Model {#trust-model}
 
-This section defines what identity means in this protocol, and what a
+This section defines the identifiers produced by this protocol and what a
 verifier can conclude from a valid signature.
 
-## The key is the identity {#key-is-identity}
+## The signing key provides continuity {#key-is-identity}
 
-In this draft, an Agent's base identity is its signing key. {{origin-binding}}
-defines a domain binding that can extend it. The `keyid` defined in
+In this draft, an Agent's signing key is its base identifier. {{origin-binding}}
+defines a domain binding a verifier can establish. The `keyid` defined in
 {{generating-http-message-signature}} is a normalised thumbprint of that key. Origins
 can log, rate limit, allowlist, or block a `keyid` the way they do IP
 addresses and User-Agent today.
@@ -197,12 +197,12 @@ validated.
 
 This protocol supports two modes. Both use the same wire format: nothing
 in a request signals a mode, and the verifier chooses what to rely on.
-In the opaque mode, the key alone is the identity. An Agent needs nothing
-more than a keypair. This document defines no rotation for this mode: a
-new key is a new identity, though a future mechanism may provide rotation.
-In the domain binding mode, the identity is a domain name. The binding
-exists only for keys published in the directory defined in {{DIRECTORY}}:
-an Agent exposes its domain to verifiers by publishing its keys there.
+In opaque mode, verification returns the key as its identifier. An Agent
+needs nothing more than a keypair. This document defines no rotation for this mode: a
+new key is a new identifier, though a future mechanism may provide rotation.
+In the domain binding mode, verification adds an authenticated domain-to-key
+binding. The binding exists only for keys published in the directory defined in {{DIRECTORY}}:
+an Agent presents a domain to verifiers by publishing its keys there.
 A verifier relying on the domain MUST validate the binding described
 above. A verifier using keys opaquely
 MAY skip that validation, in which case it obtains no binding. Domain

--- a/draft-meunier-webbotauth-httpsig-protocol.md
+++ b/draft-meunier-webbotauth-httpsig-protocol.md
@@ -53,7 +53,7 @@ informative:
 
 --- abstract
 
-This document describes an architecture for identifying automated
+This document describes a protocol for identifying automated
 traffic using {{HTTP-MESSAGE-SIGNATURES}}. The goal
 is to allow automated HTTP clients to cryptographically sign outbound
 requests, allowing HTTP servers to verify their identity with confidence.
@@ -73,10 +73,11 @@ themselves to origins for several reasons:
 4. Service level differentiation between human and automated traffic
 
 Current identification methods such as IP allowlisting, User-Agent strings, or shared API keys have
-significant limitations in security, scalability, and manageability. This document defines an
-architecture enabling agents to cryptographically identify themselves using {{HTTP-MESSAGE-SIGNATURES}}.
+significant limitations in security, scalability, and manageability. This document defines a
+protocol enabling agents to cryptographically identify themselves using {{HTTP-MESSAGE-SIGNATURES}}.
 It proposes that every request from bots be signed by a private key owned by its provider.
-This way, every origin can validate the service identity.
+This way, every origin can validate the service identity. {{trust-model}}
+defines what that identity is and what validation it establishes.
 
 # Motivation
 
@@ -108,7 +109,7 @@ mechanism that empowers small and large agents to share their identity.
 
 ## HTTP layer choice
 
-This architecture operates solely at the HTTP layer.
+This protocol operates solely at the HTTP layer.
 It allows signatures to be generated and
 verified without modifying the transport layer or TLS stack. It enables
 flexible deployment across proxies, gateways, and origin servers, and aligns
@@ -134,7 +135,70 @@ The following terms are used throughout this document:
 **Origin**
 : An HTTP server receiving signed requests that implements the HTTP protocol and verifies {{HTTP-MESSAGE-SIGNATURES}} signatures. It acts as a verifier of the signature as defined by {{HTTP-MESSAGE-SIGNATURES}}.
 
-# Architecture
+# Identity and Trust Model {#trust-model}
+
+This section defines what identity means in this protocol, and what a
+verifier can conclude from a valid signature.
+
+## The key is the identity {#key-is-identity}
+
+In this draft, an Agent's identity is its signing key. The `keyid` defined in
+{{generating-http-message-signature}} is a normalised thumbprint of that key. Origins
+can log, rate limit, allowlist, or block a `keyid` the way they do IP
+addresses and User-Agent today.
+
+Unlike an IP address, a key is cheap to mint: an Agent blocked on its `keyid`
+can rotate its key or stop sending signatures altogether. This is acceptable
+and out of scope. The protocol targets honest clients that want to accrue
+trust. An Agent that does not participate falls back to the origin's existing
+bot-management path.
+
+A valid signature proves two things: the request was produced by a holder of
+the private key, and requests with the same `keyid` come from holders of the
+same key. This is enough for an origin to build trust for a `keyid`. It
+does not say who operates the Agent, whether the Agent is benign, or whether
+the request is authorized. Those are origin policy.
+
+A verifier only needs the public key to validate a signature. Whether
+that key is bound to something more, such as a domain ({{origin-binding}}),
+is deployment specific.
+
+## Discovery is not trust {#discovery-is-not-trust}
+
+The verifier needs the public key of the client they are validating.
+{{key-distribution-and-discovery}} discusses ways to obtain it: out-of-band
+exchange, public lists, or the `Signature-Agent` header. The distribution method
+does not change what a valid signature proves.
+
+`Signature-Agent` is a client-controlled hint. Verifiers SHOULD NOT grant
+trust based on its value alone. This header can be used to triage requests, but
+trust is attached to the verified key, or to a verified binding
+({{origin-binding}}).
+
+Discovery is required for key updates (addition, removal). It is bounded by the
+caching described in {{cache-behaviour}}.
+
+## Binding a key to a Web origin {#origin-binding}
+
+By design, a key and its thumbprint form a stable identifier. When key material
+comes from the well-known directory defined in {{DIRECTORY}}, the verifier
+additionally learns which domain publishes the key. The TLS connection
+authenticates the domain serving the directory, and each advertised key signs
+the directory response, proving possession and preventing the key set from
+being re-served under a different authority (Section 5.2 of {{DIRECTORY}}).
+These signatures do not confer authority over the domain: that comes from the
+TLS connection alone.
+
+In this document, such a binding is optional. Origins MAY use it for
+accountability or to persist trust across key rotation.
+
+## Out of scope
+
+This protocol does not authenticate human users, does not provide anonymous
+authentication, and does not define authorization or delegation. See
+{{privacy-considerations}}.
+
+# Protocol Overview {#architecture}
 
 ~~~aasvg
 +--------+               +---------+                           +----------+
@@ -255,7 +319,7 @@ and request a new signature, as described in {{requesting-message-signature}}.
 
 ### Sending a request {#sending-request}
 
-An Agent SHOULD send a request with the signature generated above. Updating the architecture diagram, the flow looks as follow.
+An Agent SHOULD send a request with the signature generated above. Updating the overview diagram, the flow looks as follow.
 
 ~~~aasvg
 +---------+                                                                                  +----------+
@@ -301,16 +365,17 @@ Additional requirements are placed on this validation:
 - During step 1 to 3 included, if the Origin fails to parse the provided `Signature`, `Signature-Input`, or `Signature-Agent` headers, it MAY respond with status code 400 Bad Request as defined in {{Section 15.5.1 of HTTP}}.
 - During step 4, the Origin MAY discard signatures for which the `tag` is not set to `web-bot-auth`.
 - During step 5, the Origin MAY discard signatures for which they do not know the `keyid`.
-- During step 5, if the keyid is unknown to the origin, they MAY fetch key material as indicated by the `Signature-Agent` header defined in Section 4 of {{DIRECTORY}}.
+- During step 5, if the keyid is unknown to the origin, they MAY fetch key material as indicated by the `Signature-Agent` header defined in Section 4 of {{DIRECTORY}}. Fetching key material affects only whether verification is possible, not what a valid signature means ({{discovery-is-not-trust}}).
 
 Origin MAY require the `nonce` to satisfy certain constraints: be globally unique using a global nonce store, be unique to a specific location or time window using a local cache, or no constraint at all.
 
 ## Key Distribution and Discovery {#key-distribution-and-discovery}
 
-This section describes key discovery for the agent.
+This section describes key discovery for the agent. Discovery provides key
+material; it does not confer trust ({{discovery-is-not-trust}}).
 
 The reference for discovery is a URL. It SHOULD be an HTTPS URL. The
-`Signature-Agent` header defines typed discovery. This architecture uses these
+`Signature-Agent` header defines typed discovery. This protocol uses these
 types:
 
 `directory`
@@ -368,7 +433,7 @@ See {{signature-agent}} for more details.
 ### Signature-Key header
 
 {{SIGNATURE-KEY}} defines a separate key discovery header for HTTP Message
-Signatures. Deployments MAY use it when they need that model. This architecture
+Signatures. Deployments MAY use it when they need that model. This protocol
 uses `Signature-Agent` as its default discovery mechanism.
 
 ## Session Protocol Considerations
@@ -533,11 +598,11 @@ discussed in {{cache-behaviour}}, means that the asserted identity is not
 verified. It does not prove that the signer is malicious, and it does not make
 the request trusted. The resulting enforcement decision is local policy.
 
-# Privacy Considerations
+# Privacy Considerations {#privacy-considerations}
 
 ## Public Identity
 
-This architecture assumes that automated clients identify themselves
+This protocol assumes that automated clients identify themselves
 explicitly using digital signatures. The identity associated with a signing
 key is expected to be publicly discoverable for verification purposes. This
 reduces anonymity and allows receivers to associate requests with specific
@@ -1025,6 +1090,17 @@ Tanya Verma.
 
 # Changelog
 {:numbered="false"}
+
+draft-meunier-webbotauth-httpsig-protocol-01
+
+- Add an Identity and Trust Model section: the key is the identity, discovery
+  confers no trust, and the directory binding to a Web origin is an optional
+  layer that persists trust across key rotation. Blocking on `keyid` is
+  best-effort by design; the protocol targets honest clients accruing trust.
+  Verifiers MUST NOT grant trust on the `Signature-Agent` value alone. No wire
+  format change.
+- Describe the document as a protocol throughout, matching the draft name
+  (was: architecture).
 
 draft-meunier-webbotauth-httpsig-protocol-00
 


### PR DESCRIPTION
Rendered version [[protocol](https://thibmeu.github.io/http-message-signatures-directory/protocol-trust-model/draft-meunier-webbotauth-httpsig-protocol.html#name-identifiers-and-trust-model)] - [[directory](https://thibmeu.github.io/http-message-signatures-directory/protocol-trust-model/draft-meunier-webbotauth-httpsig-directory.html)]

Changes in directory and protocol, with the main changes being a new section in protocol to state the trust model explicitly instead of leaving it implied:

- the anchor is the key and its thumbprint. What an origin does with a recognised keyid is local policy and out of scope for this document. In all cases, a bot can rotate its key or drop the signal to stop participating.
- Signature-Agent is a discovery hint that the client controls. It does not settle the outcome of a verifier policy on its own.
- the directory binding proves possession and which domain publishes the key. Authority over the domain comes from TLS layer. Aligned wording between protocol and directory drafts.

Relates to the discussion started by Martin on https://mailarchive.ietf.org/arch/msg/web-bot-auth/IZ0Ie47iydtlC1laaJcxxxR3VW8/