### PR TITLE
Mandatory signature-agent and deferring certain primitives

### DIFF
--- a/draft-meunier-webbotauth-httpsig-protocol.md
+++ b/draft-meunier-webbotauth-httpsig-protocol.md
@@ -237,15 +237,15 @@ Resolving a `Signature-Agent` URL over TLS establishes that the host named in
 the URL served this key set at fetch time.
 Whoever controls that URL says this key signs for it. That
 is what makes the URL usable as an identifier, and all it gives you. It does
-not say that the operator of that URL is honest, or that is is the same party
+not say that the operator of that URL is honest, or that it is the same party
 everyone knows about.
 
 What matters is the association between a URL and the keys published there. A
 verifier that already holds the keys does not need to fetch it. A verifier MUST
 NOT attribute a request to a `Signature-Agent` URL unless it made this
-ssociation. This can be either by resolving the URL itself, at request time or
+association. This can be either by resolving the URL itself, at request time or
 ahead of it, or from {{redistributed-key-material}}. Verifiers may refetch a URL
-to handle up key additions and removals, bounded by {{cache-behaviour}}.
+to handle key additions and removals, bounded by {{cache-behaviour}}.
 
 Where a verifier obtains the same pair from more than one source, the newer
 pair wins, including when it omits a key that older resolution included.

--- a/draft-meunier-webbotauth-httpsig-protocol.md
+++ b/draft-meunier-webbotauth-httpsig-protocol.md
@@ -1514,6 +1514,22 @@ Martin Thomson.
 # Changelog
 {:numbered="false"}
 
+draft-meunier-webbotauth-httpsig-protocol-02
+
+- Require `Signature-Agent` on every signed request, and require each signature
+  to cover the member keyed to its own label. Drop the test vectors that omitted
+  the header. Recast the no-URL identifier as a verifier state, not an Agent
+  mode.
+- Defer `Signature-Key` to draft-hardt-httpbis-signature-key.
+- List the components an Agent may cover beyond the required set.
+- Drop the 2119 keywords from the human binding guidance in Privacy
+  Considerations.
+- Redraw the figures. The overview figure now shows the architecture, naming
+  who publishes and who resolves, rather than a message order, and places the
+  Agent inside the User. The sending figure shows key resolution following the
+  first request, conditional on the keys not already being resolved, and the
+  request example moves out of it.
+
 draft-meunier-webbotauth-httpsig-protocol-01
 
 - Add an Identifiers and Trust Model section: opaque and domain binding modes.

--- a/draft-meunier-webbotauth-httpsig-protocol.md
+++ b/draft-meunier-webbotauth-httpsig-protocol.md
@@ -216,12 +216,15 @@ are involved.
 carry continuity across a rotation, as that value is derived from the key
 material.
 
-## When no URL is sent {#no-url}
+## When no URL is available {#no-url}
 
-`Signature-Agent` is RECOMMENDED but not required. Without it, a verifier has
-only the key, and the identifier is the `keyid` thumbprint defined in
-{{generating-http-message-signature}}. Verification still works, provided the
-verifier already holds that key.
+A signed request MUST carry `Signature-Agent` ({{signature-agent}}). A verifier
+can still be left with no URL to attribute to: discovery failed with nothing
+cached ({{discovery-failure}}), redistributed material carried no proof
+({{redistributed-key-material}}), or the header is absent. The identifier is
+then the `keyid` thumbprint defined in
+{{generating-http-message-signature}}. A verifier that already holds that key
+verifies the request, and attributes it no further than the holder of that key.
 
 This mode has no rotation. A new key is a new identifier, and the verifier has
 no way to connect the two.
@@ -374,8 +377,8 @@ of the signature covering it. Signers MUST send the dictionary form. The two
 are distinguishable on the wire: a String Item begins with a double quote `"`
 while a Dictionary member key does not.
 
-It is RECOMMENDED that the Agent sends requests with `Signature-Agent` header, as described in {{sending-request}}.
-If the header is to be sent, one of its members MUST be signed as a component as defined in {{Section 2.1 of HTTP-MESSAGE-SIGNATURES}}.
+A signed request MUST carry the `Signature-Agent` header, as described in {{sending-request}}.
+Its member keyed to the signature label MUST be signed as a component as defined in {{Section 2.1 of HTTP-MESSAGE-SIGNATURES}}.
 The `Signature-Agent` member identifies where candidate key material can be found.
 The key used to verify the signature is selected by the `keyid` parameter of the
 corresponding `Signature-Input` member.
@@ -386,13 +389,12 @@ This results in the following components to be signed
 ("@authority" "signature-agent";key="sig1")
 ~~~
 
-It is RECOMMENDED that the `key` matches the signature label.
-
 ### Multiple signatures {#multiple-signatures}
 
 A request MAY contain more than one Web Bot Auth signature. Each signature is
-identified by its HTTP Message Signatures label. When `Signature-Agent` is
-present, each signer SHOULD provide a `Signature-Agent` member for its label.
+identified by its HTTP Message Signatures label. Each signer MUST provide a
+`Signature-Agent` member for its label. A verifier MUST NOT attribute a
+signature to a member that signature does not cover.
 
 A signer MAY cover members from another signature label, which preserves
 evidence that another signer contributed to the request. A signer that covers
@@ -462,14 +464,11 @@ Signature-Input: sig=("@authority" "signature-agent";key="sig");\
 Signature-Agent: sig="https://signer.example.com"
 ~~~
 
-The Agent SHOULD send requests with two headers
+A signed request carries three headers
 
 1. `Signature` defined in {{generating-http-message-signature}}
 2. `Signature-Input` defined in {{generating-http-message-signature}}
-
-As described in {{signature-agent}}, it is RECOMMENDED that the Agent also send
-the `Signature-Agent` header. Without it the Agent is identified by its key
-alone, with the consequences described in {{no-url}}.
+3. `Signature-Agent` defined in {{signature-agent}}
 
 The Origin learns the URL from the request, so it resolves keys after the
 first request rather than before it. Later requests verify from cache
@@ -1254,9 +1253,10 @@ does not say that Alice's agent authorized the remote browser to act for it.
 
 # Test Vectors
 
-These vectors exercise the minimum this document requires, so most of them
-cover `@authority` and nothing else, with an `expires` far enough out that they
-do not age. That combination is a parsing and verification exercise, not a
+Except where noted, these vectors exercise the minimum this document requires:
+`@authority` and a `Signature-Agent` member and nothing else, with an `expires`
+far enough out that they do not age. That combination is a parsing and
+verification exercise, not a
 configuration to copy: as {{generating-http-message-signature}} explains, a
 signature covering `@authority` alone is reusable against that authority for
 any method, path, and body until it expires. Deployments should cover more and
@@ -1266,41 +1266,6 @@ expire sooner.
 
 The test vectors in this section use the RSA-PSS key defined in {{Appendix B.1.2 of HTTP-MESSAGE-SIGNATURES}}.
 This section includes non-normative test vectors that may be used as test cases to validate implementation correctness.
-
-### Signature-Agent absent from the request
-
-This example presents a minimal signature using the rsa-pss-sha512 algorithm over test-request. The request does not contain
-a `Signature-Agent` header.
-
-The corresponding signature base is:
-
-~~~
-NOTE: '\' line wrapping per RFC 8792
-
-"@authority": example.com
-"@signature-params": ("@authority")\
- ;created=1735689600\
- ;keyid="oD0HwocPBSfpNy5W3bpJeyFGY_IQ_YpqxSjQ3Yd-CLA"\
- ;alg="rsa-pss-sha512"\
- ;expires=4889289600\
- ;nonce="JojDFWJ90jf+gZhdKeTyJYsu1XvNPZSFAGhvYq5SuV3gneOEUAhq+xl792WGuD1W+Dr6NRmx+m+t06NsYnL4iA=="\
- ;tag="web-bot-auth"
-~~~
-
-This results in the following Signature-Input and Signature header fields being added to the message under the label `sig1`:
-
-~~~
-NOTE: '\' line wrapping per RFC 8792
-
-Signature-Input: sig1=("@authority")\
- ;created=1735689600\
- ;keyid="oD0HwocPBSfpNy5W3bpJeyFGY_IQ_YpqxSjQ3Yd-CLA"\
- ;alg="rsa-pss-sha512"\
- ;expires=4889289600\
- ;nonce="JojDFWJ90jf+gZhdKeTyJYsu1XvNPZSFAGhvYq5SuV3gneOEUAhq+xl792WGuD1W+Dr6NRmx+m+t06NsYnL4iA=="\
- ;tag="web-bot-auth"
-Signature: sig1=:hWPaj85MWQiRkzU4jnIKvdPQiDfMCPIoxOP8nZveNc3aFQ7r/UmXWCwGNImw588iRvTFey5TR3fVEgnXpcttlyK+u5pN831z9Wlr+IMNfub4uEM3SuO+SKFygJZyLG0pf7OAiRcU4C0gyx1BS/+z9ydQTRzDLr88wCkBBRqwGRrSi8HTwxkqg1jugobh93hcnU6gV8MK1n+VnhRprIgl2RQSO6q5cfbB4OS8C4t/8ndW0lYmP2SWzKZJXnpX5Wrj17PuLqnVW6MO8pJnLAMXNvxUdx32KHeq/cHFrzZazZsua3UOoP+k+niHwoQ8bBWj1Vi4mM1mYJK+fk366cCLsQ==:
-~~~
 
 ### Signature-Agent included present on the request {#example-signature-agent-included}
 
@@ -1382,41 +1347,6 @@ Signature: sig2=:I1QWNzGXdP1a4dSvOHLCVOOanEYHDk+ZsVxM9MLX/p4ko69ghKwR5EOtAD96g7g
 
 The test vectors in this section use the Ed25519 key defined in {{Appendix B.1.4 of HTTP-MESSAGE-SIGNATURES}}.
 This section include non-normative test vectors that may be used as test cases to validate implementation correctness.
-
-### Signature-Agent absent from the request
-
-This example presents a minimal signature using the ed25519 algorithm over test-request. The request does not contain
-a `Signature-Agent` header.
-
-The corresponding signature base is:
-
-~~~
-NOTE: '\' line wrapping per RFC 8792
-
-"@authority": example.com
-"@signature-params": ("@authority")\
- ;created=1735689600\
- ;keyid="poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U"\
- ;alg="ed25519"\
- ;expires=4889289600\
- ;nonce="zIW8+cdmA3vdYagbxojpONwa/l0EKJ/O3/wD486VvsQjO/RxPaSt6ZxvQaMcQzNnqKN/mQ6hpGiFro2L2qkz5A=="\
- ;tag="web-bot-auth"
-~~~
-
-This results in the following Signature-Input and Signature header fields being added to the message under the label `sig1`:
-
-~~~
-NOTE: '\' line wrapping per RFC 8792
-
-Signature-Input: sig1=("@authority")\
- ;created=1735689600\
- ;keyid="poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U"\
- ;alg="ed25519"\
- ;expires=4889289600\
- ;nonce="zIW8+cdmA3vdYagbxojpONwa/l0EKJ/O3/wD486VvsQjO/RxPaSt6ZxvQaMcQzNnqKN/mQ6hpGiFro2L2qkz5A=="\
- ;tag="web-bot-auth"
-Signature: sig1=:QKN4fTdIYfh82fvoZCQiQA1weuozfCS/Led2zTMbewMMqH8PI2Wsy/5c4ao6B6D09nraNQdBNOADg8aM1MqfCg==:
-~~~
 
 ### Signature-Agent included present on the request
 

--- a/draft-meunier-webbotauth-httpsig-protocol.md
+++ b/draft-meunier-webbotauth-httpsig-protocol.md
@@ -347,9 +347,16 @@ signature covering `@authority` alone verifies against any method, path, or body
 sent to that authority until it expires, so anyone who observes one request can
 reuse it against the same origin until then.
 `expires` bounds how long that lasts; the covered components bound what it
-reaches. Agents that want to narrow it SHOULD also cover `@method`, and
-either `@path` or `@target-uri`, as {{example-multiple-signatures}} does. A signer that omits them remains conformant.
-{{field-compression}} covers what that costs on the wire.
+reaches. {{field-compression}} covers what that costs on the wire.
+
+Agents that want to narrow it SHOULD also cover the following components. A
+signer that omits them remains conformant.
+
+`@method`
+: narrows the signature to one method.
+
+`@path` or `@target-uri`
+: narrows it to one resource. {{example-multiple-signatures}} covers both.
 
 No component covers the body. An Agent that needs one MUST send and cover
 `Content-Digest` {{DIGEST-FIELDS}}. This document does not require it. Most

--- a/draft-meunier-webbotauth-httpsig-protocol.md
+++ b/draft-meunier-webbotauth-httpsig-protocol.md
@@ -109,7 +109,7 @@ monitor and rate limit per agent operator. However, these mechanisms have drawba
     act as that agent. It is also overloaded - an agent may be using Chromium and
     wish to present itself as such to ensure rendering works, yet it still wants to
     differentiate its traffic to the site.
- 2. IP blocks alone can present a confusing story. IPs on cloud plaforms have
+ 2. IP blocks alone can present a confusing story. IPs on cloud platforms have
     layers of ownership - the platform owns the IP and registers it in their
     published IP blocks, only to be re-published by the agent with little to bind
     the publication to the actual service provider that may be renting infra. Purchasing
@@ -722,7 +722,7 @@ needed.
 ## Key Reuse Considered Harmful
 
 Implementations SHOULD NOT reuse a signing key for different purposes. For
-example, if an agent implementor has two agents they want to differentiate,
+example, if an agent implementer has two agents they want to differentiate,
 these should use distinct signing keys and signing key directories.
 
 ## Reverse proxy consideration {#reverse-proxy}

--- a/draft-meunier-webbotauth-httpsig-protocol.md
+++ b/draft-meunier-webbotauth-httpsig-protocol.md
@@ -349,14 +349,25 @@ reuse it against the same origin until then.
 `expires` bounds how long that lasts; the covered components bound what it
 reaches. {{field-compression}} covers what that costs on the wire.
 
-Agents that want to narrow it SHOULD also cover the following components. A
-signer that omits them remains conformant.
+Agents that want to narrow the scope of their signature SHOULD also cover the
+following components. A signer that omits them remains conformant.
 
 `@method`
-: narrows the signature to one method.
+: narrows the signature to one method. Defined in {{Section 2.2.1 of HTTP-MESSAGE-SIGNATURES}}
 
-`@path` or `@target-uri`
-: narrows it to one resource. {{example-multiple-signatures}} covers both.
+`@path`
+: narrows the signature to one resource. {{example-multiple-signatures}} shows
+it in use. Defined in {{Section 2.2.6 of HTTP-MESSAGE-SIGNATURES}}.
+
+`@target-uri`
+: narrows the signature to one resource, including the query string. The
+signature is invalidated by intermediary reordering, which might happen for
+caching purposes for instance. Defined in {{Section 2.2.2 of HTTP-MESSAGE-SIGNATURES}}.
+
+`@query-param`
+: narrows the signature to individual query parameters. This is a more robust
+alternative to cover query parameters. Defined in {{Section 2.2.8 of HTTP-MESSAGE-SIGNATURES}}.
+
 
 No component covers the body. An Agent that needs one MUST send and cover
 `Content-Digest` {{DIGEST-FIELDS}}. This document does not require it. Most

--- a/draft-meunier-webbotauth-httpsig-protocol.md
+++ b/draft-meunier-webbotauth-httpsig-protocol.md
@@ -62,7 +62,6 @@ informative:
   OWASP-SSRF:
     title: OWASP Server-Side Request Forgery Prevention Cheat Sheet
     target: https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html
-  SIGNATURE-KEY: I-D.draft-hardt-httpbis-signature-key
   USE-CASES: I-D.draft-nottingham-webbotauth-use-cases
   WELLKNOWN-URI: RFC8615
 
@@ -216,10 +215,6 @@ are involved.
 `keyid` selects which key verifies a given request. Verifiers cannot use it to
 carry continuity across a rotation, as that value is derived from the key
 material.
-
-{{SIGNATURE-KEY}} takes a different approach, where a long-lived key signs
-short-lived delegated keys. Deployments MAY use it. This document does not
-define rotation that way.
 
 ## When no URL is sent {#no-url}
 
@@ -636,12 +631,6 @@ A verifier polling a directory on its own schedule is resolving it. So is a
 control plane polling on behalf of the verifiers it serves. None of these options
 constitute redistribution. Nor is a list that names directory URLs rather than embedding
 keys. For instance, {{REGISTRY}} works that way, and the verifier still resolves them.
-
-### Signature-Key header
-
-{{SIGNATURE-KEY}} defines a separate key discovery header for HTTP Message
-Signatures. Deployments MAY use it when they need that model. This protocol
-uses `Signature-Agent` as its default discovery mechanism.
 
 ## Session considerations {#sessions}
 

--- a/draft-meunier-webbotauth-httpsig-protocol.md
+++ b/draft-meunier-webbotauth-httpsig-protocol.md
@@ -278,17 +278,18 @@ document.
 # Protocol Overview
 
 ~~~aasvg
-+--------+               +---------+                           +----------+
-|        |               |         |         Exchange          |          |
-|        |               |         |<===== Cryptographic =====>|          |
-|        |               |         |         material          |          |
-|  User  +--- Request -->|  Agent  |                           |  Origin  |
-|        |               |         +--- Request + Signature -->|          |
-|        |               |         |<-------- Response --------+          |
-|        |<-- Response --+         |                           |          |
-|        |               |         |                           |          |
-+--------+               +---------+                           +----------+
++----------------+
+| User           |
+|     +-------+  |                                 +--------+
+|     | Agent +--+----- signed request + URL ----->| Origin |
+|     +---+---+  |                                 +---+----+
++---------+------+                                     |
+          |                                            |
+          |                +-----------+               |
+          +-- publishes -->| Directory |<-- resolves --+
+                           +-----------+
 ~~~
+{: title="Web Bot Auth architecture"}
 
 A User initiates an action requiring the Agent to perform an HTTP request.
 The Agent constructs the request, generates a signature using its signing key,
@@ -296,6 +297,7 @@ and includes it in the request as defined in {{Section 3.1 of HTTP-MESSAGE-SIGNA
 along with the `Signature-Agent` header for discovery of its verification key.
 Upon receiving the request, the Origin ensures it has the verification key for the Agent,
 validates the signature, and processes the request if the signature is valid.
+How a User directs an Agent is outside the scope of this document.
 
 ## Deployment Models
 
@@ -444,24 +446,20 @@ and request a new signature, as described in {{requesting-message-signature}}.
 
 ### Sending a request {#sending-request}
 
-An Agent SHOULD send a request with the signature generated above. Updating the overview diagram, the flow looks as follow.
+An Agent SHOULD send a request with the signature generated above.
 
-~~~aasvg
-+---------+                                                                                  +----------+
-|         |                                     Exchange                                     |          |
-|         |<================================  Cryptographic  ===============================>|          |
-|         |                                     material                                     |          |
-|  Agent  |                                                                                  |  Origin  |
-|         |     .-------------------------------------------------------------------.        |          |
-|         +-----| GET /path/to/resource                                             |------->|          |
-|         |     | Signature: sig=abc==                                              |        |          |
-+---------+     | Signature-Input: sig=("@authority" "signature-agent";key="sig");\ |        +----------+
-                |                  created=1700000000;\                             |
-                |                  expires=1700011111;\                             |
-                |                  keyid="ba3e64==";\                               |
-                |                  tag="web-bot-auth"                               |
-                | Signature-Agent: sig="https://signer.example.com"                 |
-                '-------------------------------------------------------------------'
+~~~
+NOTE: '\' line wrapping per RFC 8792
+
+GET /path/to/resource HTTP/1.1
+Host: origin.example.com
+Signature: sig=abc==
+Signature-Input: sig=("@authority" "signature-agent";key="sig");\
+                 created=1700000000;\
+                 expires=1700011111;\
+                 keyid="ba3e64==";\
+                 tag="web-bot-auth"
+Signature-Agent: sig="https://signer.example.com"
 ~~~
 
 The Agent SHOULD send requests with two headers
@@ -472,6 +470,29 @@ The Agent SHOULD send requests with two headers
 As described in {{signature-agent}}, it is RECOMMENDED that the Agent also send
 the `Signature-Agent` header. Without it the Agent is identified by its key
 alone, with the consequences described in {{no-url}}.
+
+The Origin learns the URL from the request, so it resolves keys after the
+first request rather than before it. Later requests verify from cache
+({{cache-behaviour}}).
+
+~~~aasvg
++-------+                   +--------+     +-----------+
+| Agent |                   | Origin |     | Directory |
++---+---+                   +---+----+     +-----+-----+
+    |                           |                |
+    +== Signed request + URL ==>|                |
+    |                           |                |
+    |                       .-- if keys not resolved --.
+    |                       |   |                |     |
+    |                       |   +--- Resolve --->|     |
+    |                       |   |<---- Keys -----+     |
+    |                       |   |                |     |
+    |                       '--------------------------'
+    |                           |                |
+    |<======== Response ========+                |
+    |                           |                |
+~~~
+{: title="Key resolution follows the first request"}
 
 ## Requesting a Message signature {#requesting-message-signature}
 

--- a/draft-meunier-webbotauth-httpsig-protocol.md
+++ b/draft-meunier-webbotauth-httpsig-protocol.md
@@ -861,11 +861,10 @@ choice of protocol for it.
 
 ## No Human Correlation
 
-The key used for signing MUST NOT be tied to a specific human individual.
-Keys SHOULD represent a role, company, or automation identity (e.g., "news-aggregator-
-bot", "example-crawler-v1"). This avoids accidental exposure of personally
-identifiable information and prevents the misuse of keys for user tracking or
-profiling.
+A key tied to a specific human individual exposes personally identifiable
+information and makes the key usable for user tracking or profiling. A key that
+represents a role, company, or automation identity (e.g., "news-aggregator-bot",
+"example-crawler-v1") avoids this.
 
 ## Minimizing Tracking Risks
 

--- a/draft-meunier-webbotauth-registry.md
+++ b/draft-meunier-webbotauth-registry.md
@@ -908,6 +908,10 @@ The editor would also like to thank the following individuals (listed in alphabe
 # Changelog
 {:numbered="false"}
 
+draft-meunier-webbotauth-registry-04
+
+- Defer `Signature-Key` to draft-hardt-httpbis-signature-key.
+
 draft-meunier-webbotauth-registry-03
 
 - Make the Signature Agent Card an OAuth client metadata document with a

--- a/draft-meunier-webbotauth-registry.md
+++ b/draft-meunier-webbotauth-registry.md
@@ -64,7 +64,6 @@ informative:
   RATELIMIT-HEADER: I-D.draft-ietf-httpapi-ratelimit-headers
   RFC8446:
   ROBOTSTXT: RFC9309
-  SIGNATURE-KEY: I-D.draft-hardt-httpbis-signature-key
   UTF8: RFC3629
 
 --- abstract
@@ -503,15 +502,6 @@ When used for HTTP Message Signatures, a Signature Agent Card MAY be discovered
 via a `Signature-Agent` header member with `type=cimd`. The URI carried in that
 member is the `client_id` of a Signature Agent Card resolved as described in
 {{cimd-discovery}}.
-
-## Composable discovery with Signature-Key {#signature-key}
-
-The discovery in this document is anchored on the `client_id` URL and is
-independent of the header that carries it. {{SIGNATURE-KEY}} defines a composable
-`Signature-Key` header with an extensible registry of key-distribution schemes.
-A future scheme could carry a `client_id` URL, letting a verifier resolve a
-Signature Agent Card per-signature alongside the keying material. This document
-does not define such a scheme; it is noted as a possible composable carrier.
 
 ## Change Notification {#change-notification}
 

--- a/draft-meunier-webbotauth-registry.md
+++ b/draft-meunier-webbotauth-registry.md
@@ -360,7 +360,7 @@ Example
 A Signature Agent Card is discovered by dereferencing its `client_id`, as
 described in {{cimd-discovery}}, or from a registry.
 
-A registry is a list of URLs, each refering to a signature agent card. An entry
+A registry is a list of URLs, each referring to a signature agent card. An entry
 MAY be the `client_id` of a Signature Agent Card.
 
 The URI scheme MUST be one of:


### PR DESCRIPTION
[iddiff](https://author-tools.ietf.org/api/iddiff?url_1=https://thibmeu.github.io/http-message-signatures-directory/draft-meunier-webbotauth-httpsig-protocol.txt&url_2=https://thibmeu.github.io/http-message-signatures-directory/review-107-116/draft-meunier-webbotauth-httpsig-protocol.txt) - [text](https://thibmeu.github.io/http-message-signatures-directory/review-107-116/draft-meunier-webbotauth-httpsig-protocol.txt) - [html](https://thibmeu.github.io/http-message-signatures-directory/review-107-116/draft-meunier-webbotauth-httpsig-protocol.html)

This change is based on review of a number of issues opened by mt, from 107 to 116. It changes

1. Signature-Agent from recommended to mandatory with a MUST. This allows to remove some text and test vectors as well.
2. reframe human consideration to be a guidance, given it cannot be enforced. it's still present as a consideration #114 
3. defer signature-key to a future wg item. per vienna comment: we should wait on httpbis here. #112 
4. Optional parameters (method, path, ...) are presented in a list to match the MUST parameters #113
5. changes diagrams to make them highlight the system rather than a specific example (mentioned in #107)
6. corrects some typos

note done in this commit but worth considering: moving the declaration of `type` and associated `cimd` into the registry draft, and consolidate signature-agent around jwks_uri. I'm in favor of having a distinct release for it (and will be a distinct PR. #109 for discussion)

@sandormajor