### PR TITLE
Add test vectors for signed directory responses (#120)

### DIFF
--- a/draft-meunier-webbotauth-httpsig-protocol.md
+++ b/draft-meunier-webbotauth-httpsig-protocol.md
@@ -1484,6 +1484,69 @@ Signature-Input: sig2=("@authority" "signature-agent")\
 Signature: sig2=:jdq0SqOwHdyHr9+r5jw3iYZH6aNGKijYp/EstF4RQTQdi5N5YYKrD+mCT1HA1nZDsi6nJKuHxUi/5Syp3rLWBA==:
 ~~~
 
+### Signed directory response
+
+This example presents the possession proof described in
+{{origin-binding-appendix}}, using the ed25519 algorithm. The directory server
+signs its own response with the key it publishes. The signature covers
+`@authority` from the request that fetched the directory, so the key set cannot
+be re-served under another authority, and `content-digest` over the response
+body, so the key set cannot be swapped under a captured signature.
+
+The proof is bound to the request that fetched the directory:
+
+~~~
+GET /.well-known/http-message-signatures-directory HTTP/1.1
+Host: signature-agent.test
+Accept: application/http-message-signatures-directory+json
+~~~
+
+The response body is the following JSON Web Key Set, signed exactly as shown,
+with no trailing newline:
+
+~~~
+NOTE: '\' line wrapping per RFC 8792
+
+{"keys":[{"kty":"OKP","crv":"Ed25519","kid":"poqkLGiymh_W0uP6PZFw-\
+ dvez3QJT5SolqXBCW38r0U","x":"JrQLj5P_89iXES9-vFgrIy29clF9CC_oPPsw\
+ 3c5D0bs","use":"sig"}]}
+~~~
+
+Those bytes give the following `Content-Digest` field value:
+
+~~~
+Content-Digest: sha-256=:CADMT2aBdV/rqQr/NIru64ERQkCobVvllA4V0fLFDu0=:
+~~~
+
+The corresponding signature base is:
+
+~~~
+NOTE: '\' line wrapping per RFC 8792
+
+"@authority";req: signature-agent.test
+"content-digest": sha-256=:CADMT2aBdV/rqQr/NIru64ERQkCobVvllA4V0fLFDu0=:
+"@signature-params": ("@authority";req "content-digest")\
+ ;created=1735689600\
+ ;expires=4889289600\
+ ;keyid="poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U"\
+ ;tag="http-message-signatures-directory"
+~~~
+
+This results in the following Content-Digest, Signature-Input and Signature
+header fields being added to the response under the label `binding`:
+
+~~~
+NOTE: '\' line wrapping per RFC 8792
+
+Content-Digest: sha-256=:CADMT2aBdV/rqQr/NIru64ERQkCobVvllA4V0fLFDu0=:
+Signature-Input: binding=("@authority";req "content-digest")\
+ ;created=1735689600\
+ ;expires=4889289600\
+ ;keyid="poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U"\
+ ;tag="http-message-signatures-directory"
+Signature: binding=:l6P8R67tm3kujAxbHWio7ll01qrEZ0dKD/WWlGhNYEmTnFZM8Wt0VQ9zqGfvo7T/UMkBxsigzChM1Gpz7gOVBg==:
+~~~
+
 # Implementations
 
 This draft has a couple of public implementations. A demonstration server has been deployed to [https://http-message-signatures-example.research.cloudflare.com/](https://http-message-signatures-example.research.cloudflare.com/).


### PR DESCRIPTION
Closes the request in #120: test vectors for directory signing, valid cases only.

**What this adds.** One new subsection, E.2.4, giving a worked example of the
possession proof on the directory response from Appendix B.1. It shows the fetch
request, the JWK Set response body byte for byte, the resulting `Content-Digest`,
the full signature base, and the `Signature-Input` and `Signature` response
fields. `created` and `expires` are the fixed constants Appendix E already uses,
1735689600 and 4889289600, so the example does not age; a long `expires` is also
what the Directory Response Signature Lifetimes guidance asks for. Ed25519 only.
Issue #11 covers the negative cases, and I have left those alone.

**Key material.** The Ed25519 key from RFC 9421 Appendix B.1.4, the same key
Appendix E already uses, under the same keyid
`poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U`. Nothing new is introduced.

**How it was produced and checked.** Every byte is generated, none hand written,
and the two paths do not share code:

1. Generation signs through our Web Bot Auth implementation, so the vector is
   what a running verifier produces.
2. Verification is a standalone script that imports nothing from that
   implementation. It recomputes `Content-Digest` from the body, rebuilds the
   signature base from the covered component list parsed out of the published
   `Signature-Input`, recomputes the JWK thumbprint to select the key, and
   verifies with node crypto. It reads those inputs back out of the rendered
   draft after RFC 8792 unfolding, so what gets verified is what the document
   prints.

Cross checks: the published `kid` equals the thumbprint computed from the key
itself; the same signature does not verify over a modified body; and, as a
control on the key material, re-signing the existing E.2.1 base reproduces its
published signature byte for byte. Generator and verifier live at
https://github.com/AVA-PAY/ava-pay/tree/main/scripts, given only as provenance.

**One caveat, and it matters.** The draft has no worked example for Appendix B.1
today, so this vector necessarily encodes one reading of the normative text:
covered components `("@authority";req "content-digest")` in that order, with
`created`, `expires`, a thumbprint `keyid`, and
`tag="http-message-signatures-directory"`. It carries no `alg` parameter, since
B.1 does not list one. If the working group intends a different construction, say
so and I will regenerate. This is material for the question rather than an answer
to it.

These came out of implementing a merchant side verifier against -01, which is why
the missing example was noticeable.