### PR TITLE
Separate the possession proof from the domain binding in Appendix B

### DIFF
--- a/draft-meunier-webbotauth-httpsig-protocol.md
+++ b/draft-meunier-webbotauth-httpsig-protocol.md
@@ -1007,15 +1007,20 @@ them. End-user authentication and anonymous authentication are out of scope.
 # Validating the Domain Binding {#origin-binding-appendix}
 
 This appendix describes what a verifier checks when it wants the domain a key
-is published under, rather than the URL on its own. It applies to the
-`directory` type in {{key-distribution-and-discovery}}. Verification,
-rotation, and continuity do not depend on any of it, and a verifier that only
-needs the URL as an identifier can skip the whole appendix.
+is published under, rather than the URL on its own. The domain binding
+described here applies to the `directory` type in
+{{key-distribution-and-discovery}}. The possession proof in
+{{possession-proof}} is not specific to that type: it covers `@authority` and
+`content-digest`, and applies to any response that serves key material,
+including one reached through `jwks_uri` or `cimd`. A verifier MAY consume it
+under {{redistributed-key-material}}. Verification, rotation, and continuity
+do not depend on any of it, and a verifier that only needs the URL as an
+identifier can skip the whole appendix.
 
 Authority over the domain comes from the TLS connection to the directory.
 Nothing below adds to that.
 
-## Possession Proof on the Directory Response
+## Possession Proof on the Directory Response {#possession-proof}
 
 It is RECOMMENDED that a directory server construct and include one HTTP
 Message Signature per key with the response, as defined in
@@ -1051,7 +1056,9 @@ consuming it through {{redistributed-key-material}}.
 : MUST be a base64url JWK SHA-256 Thumbprint as defined in {{Section 3.2 of JWK-THUMBPRINT}} for RSA and EC, and in {{Appendix A.3 of JWK-OKP}} for ed25519.
 
 `tag`
-: MUST be `http-message-signatures-directory`
+: MUST be `http-message-signatures-directory`. The value names the proof
+  mechanism rather than the resource type, and is unchanged when the proof
+  accompanies a response reached through `jwks_uri` or `cimd`.
 
 A verifier using a corresponding directory response signature as proof MUST
 validate it using the key provided by the directory and MUST validate the


### PR DESCRIPTION
Follows the discussion on #100 and the current list thread on Appendix B scope. Text only, no mechanism change.

## What this fixes

Appendix B holds two properties that behave differently. The **domain binding** is genuinely `directory`-only, because the well-known URI is reserved and an arbitrary path is not. The **possession proof** in B.1 is not: it covers `@authority` and `content-digest` and works on any response that serves key material.

The appendix opens with "It applies to the `directory` type", which is correct for the binding and reads as covering the proof too.

Section 5.5 already draws the distinction this PR carries into the appendix:

> TLS authenticates the host but not the path, and nothing reserves the `jwks_uri` or `cimd` path to the host's operator. The well-known URI is reserved, so `directory` additionally names a domain.

So this is a consistency fix rather than a new proposal.

## Why the reading matters

Under the narrow reading a `jwks_uri` or `cimd` operator cannot produce a conformant proof, since `tag` is pinned to `http-message-signatures-directory`. Two consequences follow:

- 5.5.3 will not attribute redistributed key material to their URL, so the identifier falls back to the thumbprint of 4.3, which does not survive rotation.
- Joshua Ashcroft noted on the list that Cloudflare's documentation instructs signing the directory response with one signature per key. If that artifact is required to enrol, operators on `jwks_uri` cannot produce it. I have not tested whether enrolment rejects an unsigned directory, so that is his report rather than a verified claim.

The second matters more in practice. Wenchong Dong's measurement of 11 August found no origin fetched a published directory across 294,898 signed requests, and concluded that "an allowlist is an enrolment gate under another name". If enrolment is the gate that decides who can usefully sign, an operator who cannot produce the artifact it asks for is excluded structurally rather than by choice.

## Evidence that the broad reading was intended

- #98 (merged 19 June): "We still strongly suggest that jwks_uri response is signed to bound keys to a domain."
- On #100, @thibmeu wrote that a signature over the requested authority "applies both to the delegated and same-origin", and "I would not scope the signing recommendation only to cross-origin/delegated discovery. Would that fit better?" That question was asked in June and picked up this week.
- The -01 changelog records "Move the domain binding to an appendix". The proof travelled with the binding and inherited a scope written for it.

## Implementer reports

Two independent implementers said on the list this week that they apply B.1 to `directory` responses only, because that is what the text licenses: @AVAVERIFY (merchant-side verifier, author of the E.2.3 vectors in #121) and Joshua Ashcroft (two production directories). Neither read it as a design decision.

## Changes

1. Scope paragraph: separate the binding from the proof.
2. Add `{#possession-proof}` so the scope paragraph can reference the section.
3. `tag`: a sentence saying the value names the mechanism rather than the resource type.

## The `tag`

I opened this as the part I was least sure about. RFC 9421 Section 2.3 defines it as "An application-specific tag for the signature as a String value. This value is used by applications to help identify signatures relevant for specific applications or protocols." That ties the tag to the protocol rather than to the resource being served, so one value across response types is the reading that fits rather than a stretch of what `tag` is for. @AVAVERIFY takes the same position below on interop grounds: two values would imply two validation procedures that do not exist. Still your call if you read it differently.

Two further notes. The proof stays **MAY** for non-`directory` types, since 5.5 observes those key sets may serve other consumers and mandating signatures over shared key material would be a real burden. And @AVAVERIFY has offered to extend the E.2.3 vectors to cover the proof on a `jwks_uri` response if the separation is adopted, so the type-generic claim would ship with an executable example on each side.
